### PR TITLE
fix: Changed `getFromParams()` to use Shape name instead of targetclass URI

### DIFF
--- a/src/shapes/Shape.ts
+++ b/src/shapes/Shape.ts
@@ -830,7 +830,7 @@ export abstract class Shape extends EventEmitter implements IShape
       //here we expect that we'll create a new node, so the counter will be increased when we actually create it
       postfix = NamedNode.getCounter() + 1;
     }
-    let uri = prefixURI + this.targetClass.uri + '/' + postfix;
+    let uri = prefixURI + this.name + '/' + postfix;
     return this.getFromURI(uri);
   }
 


### PR DESCRIPTION
This was done to prevent two URIs being present at once, but still have some indication as to what Shape is being generated

## Change Summary

When generating a new Shape using the `getFromParams()` method, the generated URI will now use the `.name` of the Shape on which the method was invoked, rather than its `targetClass.uri`.

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test / Verification

Before this change, the output of some code using this method would be:
```
https://quora.api.lincd.org/http://www.lincd.org/ads-ontology#Campaign/34
```

And now the output is:
```
https://quora.api.lincd.org/Campaign/34
```

## Additional information / screenshots (optional)

No additional information.
