### PR TITLE
IFileStore `accessURL` prop

### DIFF
--- a/src/interfaces/IFileStore.ts
+++ b/src/interfaces/IFileStore.ts
@@ -1,4 +1,12 @@
 export interface IFileStore {
+  /**
+   * The base URL to access the filestore's files. For example:
+   * - http://localhost:4000
+   * - https://s3.amazonaws.com/my-bucket
+   * - https://my-bucket.nyc3.digitaloceanspaces.com
+   */
+  readonly accessURL: string;
+
   init?(): Promise<any>;
 
   deleteFile(filePath: string): Promise<void>;

--- a/src/utils/LinkedFileStorage.ts
+++ b/src/utils/LinkedFileStorage.ts
@@ -2,6 +2,10 @@ import {IFileStore} from '../interfaces/IFileStore';
 
 export abstract class LinkedFileStorage {
   private static defaultStore: IFileStore;
+  
+  static get accessURL(): string {
+    return this.defaultStore.accessURL;
+  }
 
   static getDefaultStore(): IFileStore {
     return this.defaultStore;


### PR DESCRIPTION
## Change Summary
New required `accessURL` props added to `IFileStore` interface.

## Change type

- [x] feat: (new feature for the user, not a new feature for build script)
- [ ] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification
N/A

## Additional information / screenshots (optional)
This change should allow for easier URL configuration for LINCD apps with a backend - being able to have a `LocalFileStore` with the `accessURL` set to the `process.env.SITE_ROOT`, and the `S3FileStore`'s `accessURL` using the bucket URL (or CDN URL if one is set up).

It should mean that we can configure `lincd-server-utils` to access the default file store's `accessURL` to form the public URL when saving images and such, instead of trying to form the public URL based on different conditions (e.g. using a certain filestore and a specific env var is present).