### PR TITLE
Feature/enable accessurl file storage

### DIFF
--- a/src/interfaces/IFileStore.ts
+++ b/src/interfaces/IFileStore.ts
@@ -5,7 +5,7 @@ export interface IFileStore {
    * - https://s3.amazonaws.com/my-bucket
    * - https://my-bucket.nyc3.digitaloceanspaces.com
    */
-  // readonly accessURL: string;
+  readonly accessURL: string;
 
   init?(): Promise<any>;
 

--- a/src/utils/LinkedFileStorage.ts
+++ b/src/utils/LinkedFileStorage.ts
@@ -2,10 +2,19 @@ import {IFileStore} from '../interfaces/IFileStore';
 
 export abstract class LinkedFileStorage {
   private static defaultStore: IFileStore;
+  private static url: string; // default accessURL
 
   static get accessURL(): string {
-    throw new Error('Not implemented');
-    // return this.defaultStore.accessURL;
+    // check if default store is not set, return default accessURL
+    if (!this.defaultStore) {
+      return this.url;
+    }
+
+    return this.defaultStore.accessURL;
+  }
+
+  static setDefaultAccessURL(accessURL: string): string {
+    return (this.url = accessURL);
   }
 
   static getDefaultStore(): IFileStore {
@@ -39,4 +48,17 @@ export abstract class LinkedFileStorage {
   static saveFile(filePath: string, fileContent: Buffer): Promise<string> {
     return this.defaultStore.saveFile(filePath, fileContent);
   }
+}
+
+/**
+ *  get the asset include with cdn
+ *
+ * @param path asset path
+ * @param directory asset directory (optional, default is /public)
+ * @returns asset url. e.g. https://cdn.example.com/public/assets/image.png
+ */
+export function asset(path: string, directory: string = '/public'): string {
+  const accessURL = LinkedFileStorage.accessURL;
+  const assetUrl = accessURL + directory + path;
+  return assetUrl;
 }


### PR DESCRIPTION
## Change Summary

Enable accessURL for `LinkedFileStorage` and create `asset` function to get asset with CDN

## Change type

- [x] feat: (new feature for the user, not a new feature for build script)
- [ ] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

N/A

## Additional information / screenshots (optional)

N/A
