### PR TITLE
Phase 2: add minimal query builder and first select-query test in linked-js

### DIFF
--- a/rebrand/linked-js/jest.config.cjs
+++ b/rebrand/linked-js/jest.config.cjs
@@ -1,0 +1,6 @@
+/** @type {import('ts-jest/dist/types').InitialOptionsTsJest} */
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'jsdom',
+  rootDir: 'lib/cjs/tests',
+};

--- a/rebrand/linked-js/package.json
+++ b/rebrand/linked-js/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "linked-js",
+  "version": "0.0.0",
+  "license": "MPL-2.0",
+  "description": "Linked.js core query and SHACL shape DSL (no React or RDF models)",
+  "main": "lib/cjs/index.js",
+  "module": "lib/esm/index.js",
+  "exports": {
+    ".": {
+      "types": "./lib/esm/index.d.ts",
+      "import": "./lib/esm/index.js",
+      "require": "./lib/cjs/index.js"
+    },
+    "./*": {
+      "types": "./lib/esm/*.d.ts",
+      "import": "./lib/esm/*.js",
+      "require": "./lib/cjs/*.js"
+    }
+  },
+  "typesVersions": {
+    "*": {
+      "*": [
+        "lib/esm/*"
+      ]
+    }
+  },
+  "scripts": {
+    "build": "node ../../node_modules/.bin/rimraf ./lib && node ../../node_modules/.bin/tsc -p tsconfig-cjs.json && node ../../node_modules/.bin/tsc -p tsconfig-esm.json && node ./scripts/dual-package.js",
+    "compile": "echo '💫 Compiling CJS' && node ../../node_modules/.bin/tsc -p tsconfig-cjs.json && echo '💫 Compiling ESM' && node ../../node_modules/.bin/tsc -p tsconfig-esm.json",
+    "dual-package": "node ./scripts/dual-package.js",
+    "test": "node ../../node_modules/.bin/rimraf ./lib && node ../../node_modules/.bin/tsc -p tsconfig-cjs.json && node ../../node_modules/.bin/tsc -p tsconfig-esm.json && node ./scripts/dual-package.js && node ../../node_modules/.bin/jest --config jest.config.cjs"
+  },
+  "devDependencies": {
+    "@jest/globals": "^29.7.0",
+    "@types/jest": "^29.5.12",
+    "@types/node": "^20.12.7",
+    "jest": "^29.7.0",
+    "rimraf": "^5.0.7",
+    "ts-jest": "^29.1.2",
+    "typescript": "^5.7.3"
+  }
+}

--- a/rebrand/linked-js/scripts/dual-package.js
+++ b/rebrand/linked-js/scripts/dual-package.js
@@ -1,0 +1,25 @@
+const fs = require('fs');
+const path = require('path');
+
+const root = path.resolve(__dirname,'..');
+const libDir = path.join(root,'lib');
+const cjsDir = path.join(libDir,'cjs');
+const esmDir = path.join(libDir,'esm');
+
+const ensureDir = (dir) => {
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir,{recursive: true});
+  }
+};
+
+const writePackageJson = (dir,type) => {
+  ensureDir(dir);
+  const pkgPath = path.join(dir,'package.json');
+  const data = {
+    type,
+  };
+  fs.writeFileSync(pkgPath,JSON.stringify(data,null,2));
+};
+
+writePackageJson(cjsDir,'commonjs');
+writePackageJson(esmDir,'module');

--- a/rebrand/linked-js/src/index.ts
+++ b/rebrand/linked-js/src/index.ts
@@ -1,0 +1,8 @@
+export {linkedShape, literalProperty, objectProperty} from './package.js';
+export {Shape} from './shapes/Shape.js';
+export {
+  SelectQueryFactory,
+  QueryBuilderObject,
+  QueryShape,
+  QueryValue,
+} from './queries/SelectQuery.js';

--- a/rebrand/linked-js/src/interfaces/IQueryParser.ts
+++ b/rebrand/linked-js/src/interfaces/IQueryParser.ts
@@ -1,0 +1,8 @@
+import type {SelectQueryFactory} from '../queries/SelectQuery.js';
+import type {Shape} from '../shapes/Shape.js';
+
+export interface IQueryParser {
+  selectQuery<ResultType>(
+    query: SelectQueryFactory<Shape>,
+  ): Promise<ResultType>;
+}

--- a/rebrand/linked-js/src/package.ts
+++ b/rebrand/linked-js/src/package.ts
@@ -1,0 +1,2 @@
+export {linkedShape, literalProperty, objectProperty} from './shapes/decorators.js';
+export {Shape} from './shapes/Shape.js';

--- a/rebrand/linked-js/src/queries/SelectQuery.ts
+++ b/rebrand/linked-js/src/queries/SelectQuery.ts
@@ -1,0 +1,156 @@
+import {PropertyShape} from '../shapes/PropertyShape.js';
+import {Shape} from '../shapes/Shape.js';
+import {getPropertyShapeByLabel} from '../utils/ShapeClass.js';
+
+export type QueryPropertyPath = QueryStep[];
+
+export type PropertyQueryStep = {
+  property: PropertyShape;
+};
+
+export type QueryStep = PropertyQueryStep;
+
+export type SelectQuery<S = Shape> = {
+  type: 'select';
+  select: QueryPropertyPath[];
+  subject?: S;
+  limit?: number;
+  offset?: number;
+  shape?: typeof Shape;
+  singleResult?: boolean;
+};
+
+export class QueryBuilderObject {
+  constructor(
+    public property?: PropertyShape,
+    public subject?: QueryBuilderObject,
+  ) {}
+
+  getPropertyStep(): QueryStep {
+    return {
+      property: this.property,
+    };
+  }
+
+  getPropertyPath(currentPath?: QueryPropertyPath): QueryPropertyPath {
+    const path: QueryPropertyPath = currentPath ? [...currentPath] : [];
+    if (this.property) {
+      path.unshift(this.getPropertyStep());
+    }
+    if (this.subject) {
+      return this.subject.getPropertyPath(path);
+    }
+    return path;
+  }
+
+  static generatePathValue(
+    propertyShape: PropertyShape,
+    subject: QueryBuilderObject,
+  ) {
+    if (propertyShape.shape) {
+      const shapeClass = propertyShape.shape as typeof Shape;
+      return QueryShape.create(new shapeClass(), propertyShape, subject);
+    }
+    return new QueryValue(propertyShape, subject);
+  }
+}
+
+export class QueryValue extends QueryBuilderObject {}
+
+export class QueryShape extends QueryBuilderObject {
+  private proxy: QueryShape;
+
+  constructor(
+    public originalValue: Shape,
+    property?: PropertyShape,
+    subject?: QueryBuilderObject,
+  ) {
+    super(property, subject);
+  }
+
+  static create(
+    original: Shape,
+    property?: PropertyShape,
+    subject?: QueryBuilderObject,
+  ) {
+    const instance = new QueryShape(original, property, subject);
+    return this.proxifyQueryShape(instance);
+  }
+
+  private static proxifyQueryShape<T extends Shape>(queryShape: QueryShape) {
+    queryShape.proxy = new Proxy(queryShape, {
+      get(target, key) {
+        if (typeof key === 'string') {
+          if (key in queryShape) {
+            const value = (target as any)[key];
+            return typeof value === 'function' ? value.bind(target) : value;
+          }
+
+          const propertyShape = getPropertyShapeByLabel(
+            queryShape.originalValue.constructor as typeof Shape,
+            key,
+          );
+          if (propertyShape) {
+            return QueryBuilderObject.generatePathValue(propertyShape, target);
+          }
+        }
+        return undefined;
+      },
+    });
+    return queryShape.proxy;
+  }
+}
+
+export class SelectQueryFactory<S extends Shape> {
+  private traceResponse?: unknown;
+  limit?: number;
+  offset?: number;
+  singleResult?: boolean;
+
+  constructor(
+    public shape: typeof Shape,
+    private queryBuildFn?: (shape: S) => unknown,
+    private subject?: S,
+  ) {
+    this.traceResponse = this.getQueryShape();
+  }
+
+  private getQueryShape() {
+    if (!this.queryBuildFn) {
+      return undefined;
+    }
+    const dummyShape = new (this.shape as typeof Shape)() as S;
+    const queryShape = QueryShape.create(dummyShape);
+    return this.queryBuildFn(queryShape as unknown as S);
+  }
+
+  getQueryPaths(): QueryPropertyPath[] {
+    const queryPaths: QueryPropertyPath[] = [];
+    const response = this.traceResponse;
+
+    if (response instanceof QueryBuilderObject) {
+      queryPaths.push(response.getPropertyPath());
+    } else if (Array.isArray(response)) {
+      response.forEach((endValue) => {
+        if (endValue instanceof QueryBuilderObject) {
+          queryPaths.push(endValue.getPropertyPath());
+        }
+      });
+    }
+
+    return queryPaths;
+  }
+
+  getQueryObject(): SelectQuery<S> {
+    const queryPaths = this.getQueryPaths();
+    return {
+      type: 'select',
+      select: queryPaths,
+      subject: this.subject,
+      limit: this.limit,
+      offset: this.offset,
+      shape: this.shape,
+      singleResult: this.singleResult || !!this.subject,
+    } as SelectQuery<S>;
+  }
+}

--- a/rebrand/linked-js/src/shapes/PropertyShape.ts
+++ b/rebrand/linked-js/src/shapes/PropertyShape.ts
@@ -1,0 +1,19 @@
+export type PropertyShapeConfig<ShapeType> = {
+  path: string;
+  maxCount?: number;
+  shape?: ShapeType;
+};
+
+export class PropertyShape<ShapeType = unknown> {
+  label: string;
+  path: string;
+  maxCount?: number;
+  shape?: ShapeType;
+
+  constructor(label: string, config: PropertyShapeConfig<ShapeType>) {
+    this.label = label;
+    this.path = config.path;
+    this.maxCount = config.maxCount;
+    this.shape = config.shape;
+  }
+}

--- a/rebrand/linked-js/src/shapes/Shape.ts
+++ b/rebrand/linked-js/src/shapes/Shape.ts
@@ -1,0 +1,19 @@
+import {SelectQueryFactory} from '../queries/SelectQuery.js';
+import type {IQueryParser} from '../interfaces/IQueryParser.js';
+import {ShapeDefinition} from './ShapeDefinition.js';
+
+export class Shape {
+  static queryParser: IQueryParser;
+  static shape: ShapeDefinition;
+
+  static select<ShapeType extends Shape, ResultType = unknown[]>(
+    this: {new (): ShapeType; queryParser: IQueryParser},
+    selectFn?: (shape: ShapeType) => unknown,
+  ): Promise<ResultType> {
+    const query = new SelectQueryFactory(
+      this as unknown as typeof Shape,
+      selectFn,
+    );
+    return this.queryParser.selectQuery(query as SelectQueryFactory<ShapeType>);
+  }
+}

--- a/rebrand/linked-js/src/shapes/ShapeDefinition.ts
+++ b/rebrand/linked-js/src/shapes/ShapeDefinition.ts
@@ -1,0 +1,13 @@
+import {PropertyShape} from './PropertyShape.js';
+
+export class ShapeDefinition {
+  private propertyShapes: PropertyShape[] = [];
+
+  addPropertyShape(propertyShape: PropertyShape) {
+    this.propertyShapes.push(propertyShape);
+  }
+
+  getPropertyShapes(): PropertyShape[] {
+    return this.propertyShapes;
+  }
+}

--- a/rebrand/linked-js/src/shapes/decorators.ts
+++ b/rebrand/linked-js/src/shapes/decorators.ts
@@ -1,0 +1,40 @@
+import {PropertyShape, PropertyShapeConfig} from './PropertyShape.js';
+import {Shape} from './Shape.js';
+import {ShapeDefinition} from './ShapeDefinition.js';
+
+type PropertyDecoratorConfig<ShapeType> = PropertyShapeConfig<ShapeType>;
+
+const ensureShapeDefinition = (shapeClass: typeof Shape) => {
+  if (!shapeClass.shape) {
+    shapeClass.shape = new ShapeDefinition();
+  }
+};
+
+export const linkedShape = <T extends typeof Shape>(shapeClass: T): T => {
+  ensureShapeDefinition(shapeClass);
+  return shapeClass;
+};
+
+export const literalProperty = <ShapeType = unknown>(
+  config: PropertyDecoratorConfig<ShapeType>,
+) => {
+  return (target: Shape, propertyKey: string) => {
+    const shapeClass = target.constructor as typeof Shape;
+    ensureShapeDefinition(shapeClass);
+    shapeClass.shape.addPropertyShape(
+      new PropertyShape(propertyKey, config),
+    );
+  };
+};
+
+export const objectProperty = <ShapeType = unknown>(
+  config: PropertyDecoratorConfig<ShapeType>,
+) => {
+  return (target: Shape, propertyKey: string) => {
+    const shapeClass = target.constructor as typeof Shape;
+    ensureShapeDefinition(shapeClass);
+    shapeClass.shape.addPropertyShape(
+      new PropertyShape(propertyKey, config),
+    );
+  };
+};

--- a/rebrand/linked-js/src/tests/query-basic.test.ts
+++ b/rebrand/linked-js/src/tests/query-basic.test.ts
@@ -1,0 +1,42 @@
+import {describe, expect, test} from '@jest/globals';
+import {linkedShape, literalProperty, Shape} from '../package.js';
+import {SelectQueryFactory} from '../queries/SelectQuery.js';
+
+const name = 'name';
+
+@linkedShape
+class Person extends Shape {
+  @literalProperty({path: name, maxCount: 1})
+  declare name: string;
+}
+
+class QueryCaptureStore {
+  lastQuery?: ReturnType<SelectQueryFactory<Shape>['getQueryObject']>;
+
+  async selectQuery<ResultType>(query: SelectQueryFactory<Shape>) {
+    this.lastQuery = query.getQueryObject();
+    return [] as ResultType;
+  }
+}
+
+describe('query builder basics', () => {
+  test('selecting a literal property builds a query object', async () => {
+    const store = new QueryCaptureStore();
+    Person.queryParser = store;
+
+    await Person.select((p) => p.name);
+
+    const query = store.lastQuery;
+    const propertyShape = Person.shape.getPropertyShapes()[0];
+
+    expect(query?.type).toBe('select');
+    expect(query?.shape).toBe(Person);
+    expect(query?.subject).toBeUndefined();
+    expect(query?.singleResult).toBe(false);
+    expect(query?.select).toHaveLength(1);
+    expect(query?.select[0]).toHaveLength(1);
+    expect(query?.select[0][0].property).toBe(propertyShape);
+    expect(query?.select[0][0].property.label).toBe('name');
+    expect(query?.select[0][0].property.path).toBe(name);
+  });
+});

--- a/rebrand/linked-js/src/utils/ShapeClass.ts
+++ b/rebrand/linked-js/src/utils/ShapeClass.ts
@@ -1,0 +1,34 @@
+import type {PropertyShape} from '../shapes/PropertyShape.js';
+import {Shape} from '../shapes/Shape.js';
+
+export const getPropertyShapeByLabel = (
+  shapeClass: typeof Shape,
+  label: string,
+): PropertyShape | undefined => {
+  let current: typeof Shape = shapeClass;
+
+  while (current) {
+    const shapeDef = current.shape;
+    const propertyShape = shapeDef
+      ?.getPropertyShapes()
+      .find((shape) => shape.label === label);
+    if (propertyShape) {
+      return propertyShape;
+    }
+
+    const next = Object.getPrototypeOf(current);
+    if (!next || next === Shape || !(next.prototype instanceof Shape)) {
+      if (next?.shape) {
+        const nextProp = next.shape
+          .getPropertyShapes()
+          .find((shape) => shape.label === label);
+        if (nextProp) {
+          return nextProp;
+        }
+      }
+      break;
+    }
+    current = next;
+  }
+  return undefined;
+};

--- a/rebrand/linked-js/tsconfig-cjs.json
+++ b/rebrand/linked-js/tsconfig-cjs.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "es6",
+    "outDir": "lib/cjs"
+  }
+}

--- a/rebrand/linked-js/tsconfig-esm.json
+++ b/rebrand/linked-js/tsconfig-esm.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "esnext",
+    "target": "es6",
+    "outDir": "lib/esm",
+    "moduleResolution": "node"
+  }
+}

--- a/rebrand/linked-js/tsconfig.json
+++ b/rebrand/linked-js/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "sourceMap": true,
+    "declaration": true,
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true,
+    "downlevelIteration": true,
+    "resolveJsonModule": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "pretty": true,
+    "types": ["node", "jest"],
+    "baseUrl": "./",
+    "paths": {
+      "*": ["node_modules/@types/*", "../../node_modules/@types/*", "*"]
+    }
+  },
+  "include": [
+    "./src/**/*.ts",
+    "../node_modules/ts-jest/globals.d.ts"
+  ]
+}

--- a/rebranding.md
+++ b/rebranding.md
@@ -1,0 +1,29 @@
+# Linked Rebrand Plan (linked-js package extraction)
+
+## Goal
+Create a new `linked-js` package under `rebrand/linked-js` that contains the SHACL/shape/query DSL stack (no React and no RDF model classes). The new package should build cleanly and provide test coverage that validates the generated JS query objects from the TypeScript DSL.
+
+## Phased Plan
+1. **Create package skeleton**
+   - Add `rebrand/linked-js/package.json`, `tsconfig.json`, and a minimal test runner (Jest or equivalent).
+   - Add a single trivial test to verify the test harness runs.
+2. **Seed with the simplest query test**
+   - Identify the simplest existing query test (e.g., `Person.select(p => p.name)` or `Person.create` with one literal).
+   - Copy only the minimal shape/query infrastructure required for this test.
+   - Implement a way to capture the query object produced by the DSL without needing a backing store.
+   - Assert on the captured query object rather than the query results.
+3. **Incrementally port remaining tests**
+   - Migrate tests one by one, each time copying only the minimum necessary code.
+   - Keep tests focused on query-object generation (selection paths, where clauses, sorting, limits, updates/creates) rather than executing queries.
+4. **Clean up dependencies**
+   - Ensure no React dependencies remain.
+   - Remove RDF model class dependencies (e.g., `NamedNode`, `Literal`, `Quad`).
+   - Replace any remaining runtime store logic with query-object captures/mocks.
+5. **Validate build + tests**
+   - Run the new package build and test suites to confirm the package is standalone.
+
+## Milestones
+- Skeleton package with a passing trivial test.
+- First DSL-to-query-object test passing.
+- Full query test suite migrated (with updated assertions).
+- Zero React/RDF model dependencies in `linked-js`.


### PR DESCRIPTION
### Motivation
- Extract the Shape/SHACL query DSL into a standalone `rebrand/linked-js` package that does not depend on RDF model classes or React while preserving the ability to build the plain JS query objects. 
- Provide a minimal, testable slice of functionality to validate that `Shape.select(...)` calls translate into the same select-path JS object format used by the larger project. 

### Description
- Added a minimal package skeleton under `rebrand/linked-js` including TypeScript configs, dual-output helper (`scripts/dual-package.js`), and Jest config for tests. 
- Implemented a small shape metadata system and decorators with `Shape`, `ShapeDefinition`, `PropertyShape`, and `linkedShape`/`literalProperty`/`objectProperty` in `src/shapes/*` to register property shapes without RDF model types. 
- Implemented a lightweight query builder (`QueryBuilderObject`, `QueryShape`, `QueryValue`, `SelectQueryFactory`) that proxifies a dummy shape instance to trace property accesses and produce a serializable `SelectQuery` object in `src/queries/SelectQuery.ts`. 
- Replaced the placeholder test with `src/tests/query-basic.test.ts` which installs a dummy `QueryCaptureStore` as the shape `queryParser`, runs `Person.select(p => p.name)`, captures the produced query object, and asserts on its structure and property-shape metadata. 

### Testing
- Compiled and ran the package build and tests with: `cd rebrand/linked-js && node ../../node_modules/.bin/rimraf ./lib && node ../../node_modules/.bin/tsc -p tsconfig-cjs.json && node ../../node_modules/.bin/tsc -p tsconfig-esm.json && node ./scripts/dual-package.js && node ../../node_modules/.bin/jest --config jest.config.cjs`. 
- The Jest suite completed with the single new test passing: `1 passed, 1 total`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697d9344653c83228cf1487d01b67b4c)