### PR TITLE
Unify shape metadata into mutable NodeShape and adopt QResult<NodeShape> for queries

### DIFF
--- a/rebrand/linked-js/jest.config.cjs
+++ b/rebrand/linked-js/jest.config.cjs
@@ -1,0 +1,6 @@
+/** @type {import('ts-jest/dist/types').InitialOptionsTsJest} */
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'jsdom',
+  rootDir: 'lib/cjs/tests',
+};

--- a/rebrand/linked-js/package.json
+++ b/rebrand/linked-js/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "linked-js",
+  "version": "0.0.0",
+  "license": "MPL-2.0",
+  "description": "Linked.js core query and SHACL shape DSL (no React or RDF models)",
+  "main": "lib/cjs/index.js",
+  "module": "lib/esm/index.js",
+  "exports": {
+    ".": {
+      "types": "./lib/esm/index.d.ts",
+      "import": "./lib/esm/index.js",
+      "require": "./lib/cjs/index.js"
+    },
+    "./*": {
+      "types": "./lib/esm/*.d.ts",
+      "import": "./lib/esm/*.js",
+      "require": "./lib/cjs/*.js"
+    }
+  },
+  "typesVersions": {
+    "*": {
+      "*": [
+        "lib/esm/*"
+      ]
+    }
+  },
+  "scripts": {
+    "build": "node ../../node_modules/.bin/rimraf ./lib && node ../../node_modules/.bin/tsc -p tsconfig-cjs.json && node ../../node_modules/.bin/tsc -p tsconfig-esm.json && node ./scripts/dual-package.js",
+    "compile": "echo '💫 Compiling CJS' && node ../../node_modules/.bin/tsc -p tsconfig-cjs.json && echo '💫 Compiling ESM' && node ../../node_modules/.bin/tsc -p tsconfig-esm.json",
+    "dual-package": "node ./scripts/dual-package.js",
+    "test": "node ../../node_modules/.bin/rimraf ./lib && node ../../node_modules/.bin/tsc -p tsconfig-cjs.json && node ../../node_modules/.bin/tsc -p tsconfig-esm.json && node ./scripts/dual-package.js && node ../../node_modules/.bin/jest --config jest.config.cjs"
+  },
+  "devDependencies": {
+    "@jest/globals": "^29.7.0",
+    "@types/jest": "^29.5.12",
+    "@types/node": "^20.12.7",
+    "jest": "^29.7.0",
+    "rimraf": "^5.0.7",
+    "ts-jest": "^29.1.2",
+    "typescript": "^5.7.3"
+  }
+}

--- a/rebrand/linked-js/package.json
+++ b/rebrand/linked-js/package.json
@@ -25,10 +25,10 @@
     }
   },
   "scripts": {
-    "build": "node ../../node_modules/.bin/rimraf ./lib && node ../../node_modules/.bin/tsc -p tsconfig-cjs.json && node ../../node_modules/.bin/tsc -p tsconfig-esm.json && node ./scripts/dual-package.js",
+    "build": "../../node_modules/.bin/rimraf ./lib && node ../../node_modules/.bin/tsc -p tsconfig-cjs.json && node ../../node_modules/.bin/tsc -p tsconfig-esm.json && node ./scripts/dual-package.js",
     "compile": "echo '💫 Compiling CJS' && node ../../node_modules/.bin/tsc -p tsconfig-cjs.json && echo '💫 Compiling ESM' && node ../../node_modules/.bin/tsc -p tsconfig-esm.json",
     "dual-package": "node ./scripts/dual-package.js",
-    "test": "node ../../node_modules/.bin/rimraf ./lib && node ../../node_modules/.bin/tsc -p tsconfig-cjs.json && node ../../node_modules/.bin/tsc -p tsconfig-esm.json && node ./scripts/dual-package.js && node ../../node_modules/.bin/jest --config jest.config.cjs"
+    "test": "../../node_modules/.bin/rimraf ./lib && node ../../node_modules/.bin/tsc -p tsconfig-cjs.json && node ../../node_modules/.bin/tsc -p tsconfig-esm.json && node ./scripts/dual-package.js && node ../../node_modules/.bin/jest --config jest.config.cjs"
   },
   "devDependencies": {
     "@jest/globals": "^29.7.0",

--- a/rebrand/linked-js/scripts/dual-package.js
+++ b/rebrand/linked-js/scripts/dual-package.js
@@ -1,0 +1,25 @@
+const fs = require('fs');
+const path = require('path');
+
+const root = path.resolve(__dirname,'..');
+const libDir = path.join(root,'lib');
+const cjsDir = path.join(libDir,'cjs');
+const esmDir = path.join(libDir,'esm');
+
+const ensureDir = (dir) => {
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir,{recursive: true});
+  }
+};
+
+const writePackageJson = (dir,type) => {
+  ensureDir(dir);
+  const pkgPath = path.join(dir,'package.json');
+  const data = {
+    type,
+  };
+  fs.writeFileSync(pkgPath,JSON.stringify(data,null,2));
+};
+
+writePackageJson(cjsDir,'commonjs');
+writePackageJson(esmDir,'module');

--- a/rebrand/linked-js/src/index.ts
+++ b/rebrand/linked-js/src/index.ts
@@ -6,3 +6,4 @@ export {
   QueryShape,
   QueryValue,
 } from './queries/SelectQuery.js';
+export {queryTestFixtures} from './test-helpers/query-fixtures.js';

--- a/rebrand/linked-js/src/index.ts
+++ b/rebrand/linked-js/src/index.ts
@@ -1,0 +1,8 @@
+export {linkedShape, literalProperty, objectProperty} from './package.js';
+export {Shape} from './shapes/Shape.js';
+export {
+  SelectQueryFactory,
+  QueryBuilderObject,
+  QueryShape,
+  QueryValue,
+} from './queries/SelectQuery.js';

--- a/rebrand/linked-js/src/interfaces/IQueryParser.ts
+++ b/rebrand/linked-js/src/interfaces/IQueryParser.ts
@@ -1,8 +1,20 @@
+import type {CreateQueryFactory} from '../queries/CreateQuery.js';
+import type {DeleteQueryFactory} from '../queries/DeleteQuery.js';
 import type {SelectQueryFactory} from '../queries/SelectQuery.js';
+import type {UpdateQueryFactory} from '../queries/UpdateQuery.js';
 import type {Shape} from '../shapes/Shape.js';
 
 export interface IQueryParser {
   selectQuery<ResultType>(
     query: SelectQueryFactory<Shape>,
+  ): Promise<ResultType>;
+  createQuery<ResultType>(
+    query: CreateQueryFactory<Shape>,
+  ): Promise<ResultType>;
+  updateQuery<ResultType>(
+    query: UpdateQueryFactory<Shape>,
+  ): Promise<ResultType>;
+  deleteQuery<ResultType>(
+    query: DeleteQueryFactory<Shape>,
   ): Promise<ResultType>;
 }

--- a/rebrand/linked-js/src/interfaces/IQueryParser.ts
+++ b/rebrand/linked-js/src/interfaces/IQueryParser.ts
@@ -1,0 +1,8 @@
+import type {SelectQueryFactory} from '../queries/SelectQuery.js';
+import type {Shape} from '../shapes/Shape.js';
+
+export interface IQueryParser {
+  selectQuery<ResultType>(
+    query: SelectQueryFactory<Shape>,
+  ): Promise<ResultType>;
+}

--- a/rebrand/linked-js/src/interfaces/IQueryStore.ts
+++ b/rebrand/linked-js/src/interfaces/IQueryStore.ts
@@ -1,0 +1,11 @@
+import type {CreateQuery} from '../queries/CreateQuery.js';
+import type {DeleteQuery} from '../queries/DeleteQuery.js';
+import type {SelectQuery} from '../queries/SelectQuery.js';
+import type {UpdateQuery} from '../queries/UpdateQuery.js';
+
+export interface IQueryStore {
+  selectQuery<ResultType>(query: SelectQuery): Promise<ResultType>;
+  createQuery<ResultType>(query: CreateQuery): Promise<ResultType>;
+  updateQuery<ResultType>(query: UpdateQuery): Promise<ResultType>;
+  deleteQuery<ResultType>(query: DeleteQuery): Promise<ResultType>;
+}

--- a/rebrand/linked-js/src/package.ts
+++ b/rebrand/linked-js/src/package.ts
@@ -1,0 +1,2 @@
+export {linkedShape, literalProperty, objectProperty} from './shapes/decorators.js';
+export {Shape} from './shapes/Shape.js';

--- a/rebrand/linked-js/src/package.ts
+++ b/rebrand/linked-js/src/package.ts
@@ -1,2 +1,5 @@
 export {linkedShape, literalProperty, objectProperty} from './shapes/decorators.js';
 export {Shape} from './shapes/Shape.js';
+export {linkedPackage} from './utils/Package.js';
+export {LinkedStorage} from './utils/LinkedStorage.js';
+export {QueryParser} from './queries/QueryParser.js';

--- a/rebrand/linked-js/src/queries/CreateQuery.ts
+++ b/rebrand/linked-js/src/queries/CreateQuery.ts
@@ -1,0 +1,34 @@
+import {Shape} from '../shapes/Shape.js';
+import type {QResult} from './SelectQuery.js';
+import type {NodeShape} from '../shapes/ShapeDefinition.js';
+import {MutationQueryFactory, NodeDescriptionValue} from './MutationQuery.js';
+
+export type CreateQuery<ResponseType = null> = {
+  type: 'create';
+  shape: QResult<NodeShape>;
+  description: NodeDescriptionValue;
+};
+
+export class CreateQueryFactory<ShapeType extends Shape> extends MutationQueryFactory {
+  readonly description: NodeDescriptionValue;
+
+  constructor(
+    public shapeClass: typeof Shape,
+    updateObject: Record<string, unknown>,
+  ) {
+    super();
+    this.description = this.convertUpdateObject(
+      updateObject,
+      this.shapeClass.shape,
+      true,
+    );
+  }
+
+  getQueryObject(): CreateQuery {
+    return {
+      type: 'create',
+      shape: this.shapeClass.shape,
+      description: this.description,
+    };
+  }
+}

--- a/rebrand/linked-js/src/queries/DeleteQuery.ts
+++ b/rebrand/linked-js/src/queries/DeleteQuery.ts
@@ -1,0 +1,30 @@
+import {Shape} from '../shapes/Shape.js';
+import type {QResult} from './SelectQuery.js';
+import type {NodeShape} from '../shapes/ShapeDefinition.js';
+import {MutationQueryFactory, NodeId, NodeReferenceValue} from './MutationQuery.js';
+
+export type DeleteQuery = {
+  type: 'delete';
+  shape: QResult<NodeShape>;
+  ids: NodeReferenceValue[];
+};
+
+export class DeleteQueryFactory<ShapeType extends Shape> extends MutationQueryFactory {
+  readonly ids: NodeReferenceValue[];
+
+  constructor(
+    public shapeClass: typeof Shape,
+    ids: NodeId | NodeId[],
+  ) {
+    super();
+    this.ids = this.convertNodeReferences(ids);
+  }
+
+  getQueryObject(): DeleteQuery {
+    return {
+      type: 'delete',
+      shape: this.shapeClass.shape,
+      ids: this.ids,
+    };
+  }
+}

--- a/rebrand/linked-js/src/queries/MutationQuery.ts
+++ b/rebrand/linked-js/src/queries/MutationQuery.ts
@@ -1,0 +1,168 @@
+import {PropertyShape} from '../shapes/PropertyShape.js';
+import {Shape} from '../shapes/Shape.js';
+import type {QResult} from './SelectQuery.js';
+import {NodeShape} from '../shapes/ShapeDefinition.js';
+
+export type NodeReferenceValue = {id: string};
+export type NodeId = NodeReferenceValue | {uri: string} | string;
+
+export type UpdateNodePropertyValue = {
+  prop: PropertyShape;
+  val: UpdateValue;
+};
+
+export type NodeDescriptionValue = {
+  shape: QResult<NodeShape>;
+  fields: UpdateNodePropertyValue[];
+  __id?: string;
+};
+
+export type SetModificationValue = {
+  $add?: UpdateValue[];
+  $remove?: NodeReferenceValue[];
+};
+
+export type UpdateValue =
+  | string
+  | number
+  | boolean
+  | Date
+  | NodeReferenceValue
+  | NodeDescriptionValue
+  | UpdateValue[]
+  | SetModificationValue
+  | undefined;
+
+export class MutationQueryFactory {
+  protected convertNodeReference(value: NodeId): NodeReferenceValue {
+    if (typeof value === 'string') {
+      return {id: value};
+    }
+    if ('id' in value) {
+      return {id: value.id};
+    }
+    if ('uri' in value) {
+      return {id: value.uri};
+    }
+    throw new Error('Invalid node reference value');
+  }
+
+  protected convertNodeReferences(ids: NodeId | NodeId[]): NodeReferenceValue[] {
+    if (Array.isArray(ids)) {
+      return ids.map((id) => this.convertNodeReference(id));
+    }
+    return [this.convertNodeReference(ids)];
+  }
+
+  protected convertUpdateObject(
+    obj: Record<string, unknown>,
+    shape: NodeShape,
+    allowTopLevelId = false,
+  ): NodeDescriptionValue {
+    if (!obj || typeof obj !== 'object' || obj instanceof Date) {
+      throw new Error('Invalid update object');
+    }
+    if (!allowTopLevelId && 'id' in obj) {
+      throw new Error('You cannot use id in the top level of an update object');
+    }
+    return this.convertNodeDescription({...obj}, shape);
+  }
+
+  protected convertNodeDescription(
+    obj: Record<string, unknown>,
+    shape: NodeShape,
+  ): NodeDescriptionValue {
+    const props = shape.getPropertyShapes();
+    const fields: UpdateNodePropertyValue[] = [];
+    let id: string | undefined;
+    if ('__id' in obj) {
+      id = obj.__id as string;
+      delete obj.__id;
+    }
+    Object.keys(obj).forEach((key) => {
+      const propShape = props.find((p) => p.label === key);
+      if (!propShape) {
+        throw new Error(`Invalid property key: ${key}`);
+      }
+      fields.push({
+        prop: propShape,
+        val: this.convertUpdateValue(obj[key], propShape),
+      });
+    });
+    const description: NodeDescriptionValue = {
+      shape,
+      fields,
+    };
+    if (id) {
+      description.__id = id;
+    }
+    return description;
+  }
+
+  protected convertSetModification(
+    value: Record<string, unknown>,
+    propShape: PropertyShape,
+  ): SetModificationValue {
+    const result: SetModificationValue = {};
+    if ('add' in value) {
+      const addValue = value.add;
+      result.$add = Array.isArray(addValue)
+        ? addValue.map((v) => this.convertUpdateValue(v, propShape))
+        : [this.convertUpdateValue(addValue, propShape)];
+    }
+    if ('remove' in value) {
+      const removeValue = value.remove;
+      const toRemove = Array.isArray(removeValue) ? removeValue : [removeValue];
+      result.$remove = toRemove.map((v) => this.convertNodeReference(v as NodeId));
+    }
+    return result;
+  }
+
+  protected isSetModification(value: Record<string, unknown>): boolean {
+    const hasAdd = 'add' in value;
+    const hasRemove = 'remove' in value;
+    const numKeys = Object.keys(value).length;
+    return (hasAdd || hasRemove) && numKeys <= 2;
+  }
+
+  protected convertUpdateValue(
+    value: unknown,
+    propShape?: PropertyShape,
+  ): UpdateValue {
+    if (
+      typeof value === 'string' ||
+      typeof value === 'number' ||
+      typeof value === 'boolean' ||
+      value instanceof Date
+    ) {
+      return value;
+    }
+    if (typeof value === 'undefined') {
+      return undefined;
+    }
+    if (value === null) {
+      return undefined;
+    }
+    if (Array.isArray(value)) {
+      return value.map((item) => this.convertUpdateValue(item, propShape));
+    }
+    if (typeof value === 'object') {
+      const record = value as Record<string, unknown>;
+      if ('id' in record || 'uri' in record) {
+        return this.convertNodeReference(record as NodeId);
+      }
+      if (this.isSetModification(record)) {
+        return this.convertSetModification(record, propShape);
+      }
+      const shapeClass =
+        propShape?.valueShapeClass || (propShape?.shape as unknown as typeof Shape);
+      if (!shapeClass?.shape) {
+        throw new Error(
+          `Cannot update property ${propShape?.label ?? ''} without shape`,
+        );
+      }
+      return this.convertNodeDescription(record, shapeClass.shape);
+    }
+    throw new Error('Invalid update value');
+  }
+}

--- a/rebrand/linked-js/src/queries/QueryParser.ts
+++ b/rebrand/linked-js/src/queries/QueryParser.ts
@@ -1,0 +1,40 @@
+import type {CreateQueryFactory} from './CreateQuery.js';
+import type {DeleteQueryFactory} from './DeleteQuery.js';
+import type {SelectQueryFactory} from './SelectQuery.js';
+import type {UpdateQueryFactory} from './UpdateQuery.js';
+import type {Shape} from '../shapes/Shape.js';
+import {LinkedStorage} from '../utils/LinkedStorage.js';
+
+export class QueryParser {
+  static selectQuery<ResultType>(query: SelectQueryFactory<Shape>) {
+    const queryObject = query.getQueryObject();
+    return LinkedStorage.selectQuery<ResultType>(
+      queryObject,
+      queryObject.shape,
+    );
+  }
+
+  static createQuery<ResultType>(query: CreateQueryFactory<Shape>) {
+    const queryObject = query.getQueryObject();
+    return LinkedStorage.createQuery<ResultType>(
+      queryObject,
+      query.shapeClass,
+    );
+  }
+
+  static updateQuery<ResultType>(query: UpdateQueryFactory<Shape>) {
+    const queryObject = query.getQueryObject();
+    return LinkedStorage.updateQuery<ResultType>(
+      queryObject,
+      query.shapeClass,
+    );
+  }
+
+  static deleteQuery<ResultType>(query: DeleteQueryFactory<Shape>) {
+    const queryObject = query.getQueryObject();
+    return LinkedStorage.deleteQuery<ResultType>(
+      queryObject,
+      query.shapeClass,
+    );
+  }
+}

--- a/rebrand/linked-js/src/queries/SelectQuery.ts
+++ b/rebrand/linked-js/src/queries/SelectQuery.ts
@@ -2,6 +2,16 @@ import {PropertyShape} from '../shapes/PropertyShape.js';
 import {Shape} from '../shapes/Shape.js';
 import {getPropertyShapeByLabel} from '../utils/ShapeClass.js';
 
+export type JSNonNullPrimitive = string | number | boolean | Date;
+export type JSPrimitive = JSNonNullPrimitive | null | undefined;
+
+export type SingleResult<ResultType> =
+  ResultType extends Array<infer R>
+    ? R
+    : ResultType extends Set<infer R>
+      ? R
+      : ResultType;
+
 export type CustomQueryObject = {[key: string]: QueryPath};
 
 export type QueryPath =
@@ -49,7 +59,7 @@ export type WhereEvaluationPath = {
   args: QueryArg[];
 };
 
-export type QueryArg = {id: string} | string | number | boolean | Date | WherePath;
+export type QueryArg = {id: string} | JSNonNullPrimitive | WherePath;
 
 export type SortByPath = {
   paths: QueryPath[] | CustomQueryObject;
@@ -60,7 +70,7 @@ export type SelectQuery<S = Shape> = {
   type: 'select';
   select: QueryPath[];
   sortBy?: SortByPath;
-  subject?: S;
+  subject?: S | QResult<S>;
   limit?: number;
   offset?: number;
   shape?: typeof Shape;
@@ -68,11 +78,187 @@ export type SelectQuery<S = Shape> = {
   where?: WherePath;
 };
 
-export type QResult<ShapeType extends Shape = Shape, Object = {}> = Object & {
+export type QResult<ShapeType = Shape, Object = {}> = Object & {
   id: string;
 };
 
-export class QueryBuilderObject {
+export type QueryBuildFn<T extends Shape, ResponseType> = (
+  p: QShape<T>,
+  q?: SelectQueryFactory<T>,
+) => ResponseType;
+
+export type QueryShapeProps<
+  T extends Shape,
+  Source,
+  Property extends string | number | symbol = any,
+> = {
+  [P in keyof T]: ToQueryBuilderObject<T[P], QShape<T, Source, Property>, P>;
+};
+
+export type QueryShapeSetProps<SourceShapeSet, ShapeType> = {
+  [P in keyof ShapeType]: ToQueryBuilderObject<ShapeType[P], SourceShapeSet, P>;
+};
+
+export type QShapeSet<
+  ShapeType extends Shape,
+  Source = null,
+  Property extends string | number | symbol = null,
+> = QueryShapeSet<ShapeType, Source, Property> &
+  QueryShapeSetProps<
+    QueryShapeSet<ShapeType, Source, Property>,
+    ShapeType
+  >;
+
+export type QShape<
+  T extends Shape,
+  Source = any,
+  Property extends string | number | symbol = any,
+> = QueryShape<T, Source, Property> & QueryShapeProps<T, Source, Property>;
+
+export type ToQueryBuilderObject<
+  T,
+  Source = null,
+  Property extends string | number | symbol = '',
+> = T extends Shape
+  ? QShape<T, Source, Property>
+  : T extends JSNonNullPrimitive
+    ? QueryPrimitive<T, Source, Property>
+    : T extends Array<infer AT>
+      ? AT extends Shape
+        ? QShapeSet<AT, Source, Property>
+        : AT extends JSNonNullPrimitive
+          ? QueryPrimitiveSet<QueryPrimitive<AT, Source, Property>>
+          : QueryBuilderObject<T, Source, Property>
+      : QueryBuilderObject<T, Source, Property>;
+
+export type PatchedQueryPromise<ResultType, ShapeType extends Shape> = {
+  where?(
+    validation: (shape: ShapeType) => Evaluation | WhereBuilder,
+  ): PatchedQueryPromise<ResultType, ShapeType>;
+  limit?(lim: number): PatchedQueryPromise<ResultType, ShapeType>;
+  sortBy?(
+    sortParam: any,
+    direction?: 'ASC' | 'DESC',
+  ): PatchedQueryPromise<ResultType, ShapeType>;
+  one?(): PatchedQueryPromise<SingleResult<ResultType>, ShapeType>;
+} & Promise<ResultType>;
+
+export type QueryResponseToResultType<
+  T,
+  QShapeType extends Shape = Shape,
+  HasName = false,
+> = T extends QueryBuilderObject
+  ? GetQueryObjectResultType<T, {}, false, HasName>
+  : T extends SelectQueryFactory<any, infer Response, infer Source>
+    ? GetNestedQueryResultType<Response, Source>
+    : T extends Array<infer Type>
+      ? UnionToIntersection<QueryResponseToResultType<Type>>
+      : T extends Evaluation
+        ? boolean
+        : T extends Object
+          ? QResult<QShapeType, Prettify<ObjectToPlainResult<T>>>
+          : never;
+
+export type GetQueryResponseType<Q> =
+  Q extends SelectQueryFactory<any, infer ResponseType> ? ResponseType : Q;
+
+type UnionToIntersection<U> = (U extends any ? (x: U) => void : never) extends (
+  x: infer I,
+) => void
+  ? I
+  : never;
+
+type Prettify<T> = {[K in keyof T]: T[K]} & {};
+
+type GetNestedQueryResultType<Response, Source> =
+  Source extends QueryBuilderObject
+    ? GetQueryObjectResultType<Source, QueryResponseToResultType<Response>>
+    : QueryResponseToResultType<Response>[];
+
+type QueryValueIntersectionToObject<QueryValue> =
+  QueryValue extends QueryBuilderObject
+    ? GetQueryObjectResultType<QueryValue>
+    : never;
+
+type ResponseToObject<R> =
+  R extends Array<infer Type extends QueryBuilderObject>
+    ? QueryValueIntersectionToObject<Type>
+    : Prettify<ObjectToPlainResult<R>>;
+
+type ObjectToPlainResult<T> = {
+  [P in keyof T]: QueryResponseToResultType<T[P], null, true>;
+};
+
+type CreateQResult<
+  Source,
+  Value,
+  Property extends string | number | symbol = any,
+  SubProperties = {},
+  HasName = false,
+> = Source extends QueryBuilderObject
+  ? QResult<
+      GetSourceShape<Source>,
+      (Property extends null
+        ? {}
+        : {
+            [P in Property as HasName extends true ? `${P & string}` : P]:
+              Value;
+          }) &
+        SubProperties
+    >
+  : Value;
+
+type CreateShapeSetQResult<
+  ShapeType extends Shape,
+  Source,
+  Property extends string | number | symbol = any,
+  SubProperties = {},
+  HasName = false,
+> = CreateQResult<
+  Source,
+  QResult<ShapeType, SubProperties>[],
+  Property,
+  {},
+  HasName
+>;
+
+type GetSourceShape<Source> =
+  Source extends QueryShape<infer ShapeType, any, any> ? ShapeType : Shape;
+
+type GetQueryObjectResultType<
+  QV,
+  SubProperties = {},
+  PrimitiveArray = false,
+  HasName = false,
+> = QV extends SetSize<infer Source>
+  ? CreateQResult<Source, number, null, SubProperties, HasName>
+  : QV extends QueryPrimitive<infer Primitive, infer Source, infer Property>
+    ? CreateQResult<
+        Source,
+        PrimitiveArray extends true ? Primitive[] : Primitive,
+        Property,
+        {},
+        HasName
+      >
+    : QV extends QueryShape<infer ShapeType, infer Source, infer Property>
+      ? CreateQResult<Source, ShapeType, Property, SubProperties, HasName>
+      : QV extends QueryShapeSet<infer ShapeType, infer Source, infer Property>
+        ? CreateShapeSetQResult<
+            ShapeType,
+            Source,
+            Property,
+            SubProperties,
+            HasName
+          >
+        : QV extends QueryPrimitiveSet<infer QPrimitive>
+          ? GetQueryObjectResultType<QPrimitive, SubProperties, true, HasName>
+          : SubProperties;
+
+export class QueryBuilderObject<
+  OriginalValue = any,
+  Source = any,
+  Property extends string | number | symbol = any,
+> {
   wherePath?: WherePath;
 
   constructor(
@@ -128,9 +314,54 @@ export class QueryBuilderObject {
   }
 }
 
-export class QueryValue extends QueryBuilderObject {}
+export class QueryPrimitive<
+  T,
+  Source = any,
+  Property extends string | number | symbol = any,
+> extends QueryBuilderObject<T, Source, Property> {}
 
-export class QueryShape extends QueryBuilderObject {
+export class QueryString<
+  Source = any,
+  Property extends string | number | symbol = any,
+> extends QueryPrimitive<string, Source, Property> {}
+
+export class QueryNumber<
+  Source = any,
+  Property extends string | number | symbol = any,
+> extends QueryPrimitive<number, Source, Property> {}
+
+export class QueryBoolean<
+  Source = any,
+  Property extends string | number | symbol = any,
+> extends QueryPrimitive<boolean, Source, Property> {}
+
+export class QueryDate<
+  Source = any,
+  Property extends string | number | symbol = any,
+> extends QueryPrimitive<Date, Source, Property> {}
+
+export class QueryPrimitiveSet<
+  QPrimitive extends QueryPrimitive<any> = QueryPrimitive<any>,
+> extends QueryBuilderObject {
+  constructor(
+    public property?: PropertyShape,
+    public subject?: QueryBuilderObject,
+  ) {
+    super(property, subject);
+  }
+
+  size() {
+    return new SetSize(this);
+  }
+}
+
+export class QueryValue extends QueryPrimitive<any, any, any> {}
+
+export class QueryShape<
+  S extends Shape = Shape,
+  Source = any,
+  Property extends string | number | symbol = any,
+> extends QueryBuilderObject<S, Source, Property> {
   private proxy: QueryShape;
 
   constructor(
@@ -173,9 +404,9 @@ export class QueryShape extends QueryBuilderObject {
     return queryShape.proxy;
   }
 
-  select<Response>(selectFn: (shape: Shape) => Response) {
+  select<Response>(selectFn: QueryBuildFn<S, Response>) {
     return new SelectQueryFactory(
-      this.originalValue.constructor as typeof Shape,
+      this.originalValue.constructor as {new (): S},
       selectFn,
       undefined,
       this.getPropertyPath(),
@@ -187,7 +418,11 @@ export class QueryShape extends QueryBuilderObject {
   }
 }
 
-export class QueryShapeSet extends QueryBuilderObject {
+export class QueryShapeSet<
+  S extends Shape = Shape,
+  Source = any,
+  Property extends string | number | symbol = any,
+> extends QueryBuilderObject<S, Source, Property> {
   private proxy: QueryShapeSet;
 
   constructor(
@@ -230,7 +465,9 @@ export class QueryShapeSet extends QueryBuilderObject {
     return queryShape.proxy;
   }
 
-  some(validation: (shape: Shape) => Evaluation | WhereBuilder): Evaluation {
+  some(
+    validation: (shape: QueryBuilderObject) => Evaluation | WhereBuilder,
+  ): Evaluation {
     return new Evaluation({
       path: this.getPropertyPath(),
       method: WhereMethods.SOME,
@@ -238,7 +475,9 @@ export class QueryShapeSet extends QueryBuilderObject {
     });
   }
 
-  every(validation: (shape: Shape) => Evaluation | WhereBuilder): Evaluation {
+  every(
+    validation: (shape: QueryBuilderObject) => Evaluation | WhereBuilder,
+  ): Evaluation {
     return new Evaluation({
       path: this.getPropertyPath(),
       method: WhereMethods.EVERY,
@@ -251,9 +490,9 @@ export class QueryShapeSet extends QueryBuilderObject {
     return this;
   }
 
-  select<Response>(selectFn: (shape: Shape) => Response) {
+  select<Response>(selectFn: QueryBuildFn<S, Response>) {
     return new SelectQueryFactory(
-      this.originalValue.constructor as typeof Shape,
+      this.originalValue.constructor as {new (): S},
       selectFn,
       undefined,
       this.getPropertyPath(),
@@ -265,19 +504,36 @@ export class QueryShapeSet extends QueryBuilderObject {
   }
 
   size() {
-    return new QueryCount(this);
+    return new SetSize(this);
   }
 }
 
-export class QueryCount {
-  constructor(private source: QueryBuilderObject) {}
+export class SetSize<Source = null> extends QueryNumber<Source> {
+  constructor(
+    public subject: QueryShapeSet | QueryShape | QueryPrimitiveSet,
+    public countable?: QueryBuilderObject,
+    public label?: string,
+  ) {
+    super();
+  }
+
+  as(label: string) {
+    this.label = label;
+    return this;
+  }
 
   getPropertyPath(): QueryPropertyPath {
-    return [
-      {
-        count: this.source.getPropertyPath(),
-      },
-    ];
+    const countable = this.subject.getPropertyStep();
+    const self: SizeStep = {
+      count: [countable],
+      label: this.label || this.subject.property?.label,
+    };
+    if ((this.subject as QueryBuilderObject).subject) {
+      const path = (this.subject as QueryBuilderObject).subject.getPropertyPath();
+      path.push(self);
+      return path;
+    }
+    return [self];
   }
 }
 
@@ -332,8 +588,8 @@ const processWhereClause = (
   return getWherePath(result);
 };
 
-export class SelectQueryFactory<S extends Shape> {
-  private traceResponse?: unknown;
+export class SelectQueryFactory<S extends Shape, ResponseType = any, Source = any> {
+  private traceResponse?: ResponseType;
   limit?: number;
   offset?: number;
   singleResult?: boolean;
@@ -342,37 +598,37 @@ export class SelectQueryFactory<S extends Shape> {
   private sortDirection?: string;
 
   constructor(
-    public shape: typeof Shape,
-    private queryBuildFn?: (shape: S) => unknown,
+    public shape: {new (): S},
+    private queryBuildFn?: QueryBuildFn<S, ResponseType>,
     private subject?: S,
     private parentQueryPath?: QueryPropertyPath,
   ) {
     this.traceResponse = this.getQueryShape();
   }
 
-  private getQueryShape() {
+  private getQueryShape(): ResponseType {
     if (!this.queryBuildFn) {
       return undefined;
     }
-    const dummyShape = new (this.shape as typeof Shape)() as S;
-    const queryShape = QueryShape.create(dummyShape);
-    return this.queryBuildFn(queryShape as unknown as S);
+    const dummyShape = new this.shape() as S;
+    const queryShape =
+      QueryShape.create(dummyShape) as unknown as QShape<S>;
+    return this.queryBuildFn(queryShape, this);
   }
 
-  getQueryPaths(response = this.traceResponse): QueryPath[] | CustomQueryObject {
+  getQueryPaths(
+    response: ResponseType = this.traceResponse,
+  ): QueryPath[] | CustomQueryObject {
     let queryPaths: QueryPath[] = [];
     let queryObject: CustomQueryObject | undefined;
 
-    if (
-      response instanceof QueryBuilderObject ||
-      response instanceof QueryCount
-    ) {
+    if (response instanceof QueryBuilderObject || response instanceof SetSize) {
       queryPaths.push(response.getPropertyPath());
     } else if (Array.isArray(response)) {
       response.forEach((endValue) => {
         if (endValue instanceof QueryBuilderObject) {
           queryPaths.push(endValue.getPropertyPath());
-        } else if (endValue instanceof QueryCount) {
+        } else if (endValue instanceof SetSize) {
           queryPaths.push(endValue.getPropertyPath());
         } else if (endValue instanceof SelectQueryFactory) {
           queryPaths.push(endValue.getQueryPaths() as unknown as QueryPath);
@@ -388,7 +644,7 @@ export class SelectQueryFactory<S extends Shape> {
         const value = response[key];
         if (value instanceof QueryBuilderObject) {
           queryObject[key] = value.getPropertyPath();
-        } else if (value instanceof QueryCount) {
+        } else if (value instanceof SetSize) {
           queryObject[key] = value.getPropertyPath();
         } else if (value instanceof Evaluation || value instanceof WhereBuilder) {
           queryObject[key] = getWherePath(value);
@@ -418,14 +674,14 @@ export class SelectQueryFactory<S extends Shape> {
       subject: this.subject,
       limit: this.limit,
       offset: this.offset,
-      shape: this.shape,
+      shape: this.shape as unknown as typeof Shape,
       singleResult: this.singleResult || !!this.subject,
       where: this.wherePath,
     } as SelectQuery<S>;
   }
 
   where(validation: (shape: S) => Evaluation | WhereBuilder) {
-    const dummyShape = new (this.shape as typeof Shape)() as S;
+    const dummyShape = new this.shape() as S;
     const queryShape = QueryShape.create(dummyShape);
     this.wherePath = processWhereClause(
       validation as unknown as (
@@ -437,7 +693,7 @@ export class SelectQueryFactory<S extends Shape> {
   }
 
   sortBy<R>(sortFn: (shape: S) => R, direction = 'ASC') {
-    const dummyShape = new (this.shape as typeof Shape)() as S;
+    const dummyShape = new this.shape() as S;
     const queryShape = QueryShape.create(dummyShape);
     if (sortFn) {
       this.sortResponse = sortFn(queryShape as unknown as S);
@@ -451,13 +707,10 @@ export class SelectQueryFactory<S extends Shape> {
     return this;
   }
 
-  patchResultPromise<ResultType>(promise: Promise<ResultType>) {
-    const patched = promise as Promise<ResultType> & {
-      where?: (validation: (shape: S) => Evaluation | WhereBuilder) => typeof patched;
-      limit?: (limit: number) => typeof patched;
-      one?: () => typeof patched;
-      sortBy?: (sortFn: (shape: S) => unknown, direction?: string) => typeof patched;
-    };
+  patchResultPromise<ResultType>(
+    promise: Promise<ResultType>,
+  ): PatchedQueryPromise<ResultType, S> {
+    const patched = promise as PatchedQueryPromise<ResultType, S>;
     patched.where = (validation) => {
       this.where(validation);
       return patched;
@@ -473,7 +726,7 @@ export class SelectQueryFactory<S extends Shape> {
     patched.one = () => {
       this.setLimit(1);
       this.singleResult = true;
-      return patched;
+      return patched as PatchedQueryPromise<SingleResult<ResultType>, S>;
     };
     return patched;
   }
@@ -483,7 +736,7 @@ export class SelectQueryFactory<S extends Shape> {
       return undefined;
     }
     return {
-      paths: this.getQueryPaths(this.sortResponse),
+      paths: this.getQueryPaths(this.sortResponse as ResponseType),
       direction: this.sortDirection || 'ASC',
     };
   }

--- a/rebrand/linked-js/src/queries/SelectQuery.ts
+++ b/rebrand/linked-js/src/queries/SelectQuery.ts
@@ -2,25 +2,79 @@ import {PropertyShape} from '../shapes/PropertyShape.js';
 import {Shape} from '../shapes/Shape.js';
 import {getPropertyShapeByLabel} from '../utils/ShapeClass.js';
 
+export type CustomQueryObject = {[key: string]: QueryPath};
+
+export type QueryPath =
+  | QueryStep[]
+  | QueryPropertyPath
+  | WherePath
+  | CustomQueryObject
+  | QueryPath[];
+
 export type QueryPropertyPath = QueryStep[];
 
 export type PropertyQueryStep = {
   property: PropertyShape;
+  where?: WherePath;
 };
 
-export type QueryStep = PropertyQueryStep;
+export type SizeStep = {
+  count: QueryPropertyPath;
+  label?: string;
+};
+
+export type QueryStep = PropertyQueryStep | SizeStep;
+
+export type WhereAndOr = {
+  firstPath: WherePath;
+  andOr: AndOrQueryToken[];
+};
+
+export type AndOrQueryToken = {
+  and?: WherePath;
+  or?: WherePath;
+};
+
+export enum WhereMethods {
+  EQUALS = '=',
+  SOME = 'some',
+  EVERY = 'every',
+}
+
+export type WherePath = WhereEvaluationPath | WhereAndOr;
+
+export type WhereEvaluationPath = {
+  path: QueryPropertyPath;
+  method: WhereMethods;
+  args: QueryArg[];
+};
+
+export type QueryArg = {id: string} | string | number | boolean | Date | WherePath;
+
+export type SortByPath = {
+  paths: QueryPath[] | CustomQueryObject;
+  direction: string;
+};
 
 export type SelectQuery<S = Shape> = {
   type: 'select';
-  select: QueryPropertyPath[];
+  select: QueryPath[];
+  sortBy?: SortByPath;
   subject?: S;
   limit?: number;
   offset?: number;
   shape?: typeof Shape;
   singleResult?: boolean;
+  where?: WherePath;
+};
+
+export type QResult<ShapeType extends Shape = Shape, Object = {}> = Object & {
+  id: string;
 };
 
 export class QueryBuilderObject {
+  wherePath?: WherePath;
+
   constructor(
     public property?: PropertyShape,
     public subject?: QueryBuilderObject,
@@ -29,6 +83,7 @@ export class QueryBuilderObject {
   getPropertyStep(): QueryStep {
     return {
       property: this.property,
+      where: this.wherePath,
     };
   }
 
@@ -43,13 +98,31 @@ export class QueryBuilderObject {
     return path;
   }
 
+  equals(value: QueryArg): Evaluation {
+    return new Evaluation({
+      path: this.getPropertyPath(),
+      method: WhereMethods.EQUALS,
+      args: [value],
+    });
+  }
+
+  where(validation: (value: QueryBuilderObject) => Evaluation | WhereBuilder): this {
+    this.wherePath = processWhereClause(validation, this);
+    return this;
+  }
+
   static generatePathValue(
     propertyShape: PropertyShape,
     subject: QueryBuilderObject,
   ) {
-    if (propertyShape.shape) {
-      const shapeClass = propertyShape.shape as typeof Shape;
-      return QueryShape.create(new shapeClass(), propertyShape, subject);
+    if (propertyShape.valueShapeClass || typeof propertyShape.shape === 'function') {
+      const shapeClass =
+        propertyShape.valueShapeClass ||
+        (propertyShape.shape as unknown as typeof Shape);
+      if (propertyShape.maxCount === 1) {
+        return QueryShape.create(new shapeClass(), propertyShape, subject);
+      }
+      return QueryShapeSet.create(new shapeClass(), propertyShape, subject);
     }
     return new QueryValue(propertyShape, subject);
   }
@@ -99,18 +172,180 @@ export class QueryShape extends QueryBuilderObject {
     });
     return queryShape.proxy;
   }
+
+  select<Response>(selectFn: (shape: Shape) => Response) {
+    return new SelectQueryFactory(
+      this.originalValue.constructor as typeof Shape,
+      selectFn,
+      undefined,
+      this.getPropertyPath(),
+    );
+  }
+
+  as(shapeClass: typeof Shape) {
+    return QueryShape.create(new shapeClass(), this.property, this.subject);
+  }
 }
+
+export class QueryShapeSet extends QueryBuilderObject {
+  private proxy: QueryShapeSet;
+
+  constructor(
+    public originalValue: Shape,
+    property?: PropertyShape,
+    subject?: QueryBuilderObject,
+  ) {
+    super(property, subject);
+  }
+
+  static create(
+    original: Shape,
+    property?: PropertyShape,
+    subject?: QueryBuilderObject,
+  ) {
+    const instance = new QueryShapeSet(original, property, subject);
+    return this.proxifyQueryShapeSet(instance);
+  }
+
+  private static proxifyQueryShapeSet(queryShape: QueryShapeSet) {
+    queryShape.proxy = new Proxy(queryShape, {
+      get(target, key) {
+        if (typeof key === 'string') {
+          if (key in queryShape) {
+            const value = (target as any)[key];
+            return typeof value === 'function' ? value.bind(target) : value;
+          }
+
+          const propertyShape = getPropertyShapeByLabel(
+            queryShape.originalValue.constructor as typeof Shape,
+            key,
+          );
+          if (propertyShape) {
+            return QueryBuilderObject.generatePathValue(propertyShape, target);
+          }
+        }
+        return undefined;
+      },
+    });
+    return queryShape.proxy;
+  }
+
+  some(validation: (shape: Shape) => Evaluation | WhereBuilder): Evaluation {
+    return new Evaluation({
+      path: this.getPropertyPath(),
+      method: WhereMethods.SOME,
+      args: [processWhereClause(validation, this.proxy)],
+    });
+  }
+
+  every(validation: (shape: Shape) => Evaluation | WhereBuilder): Evaluation {
+    return new Evaluation({
+      path: this.getPropertyPath(),
+      method: WhereMethods.EVERY,
+      args: [processWhereClause(validation, this.proxy)],
+    });
+  }
+
+  where(validation: (value: QueryBuilderObject) => Evaluation | WhereBuilder): this {
+    this.wherePath = processWhereClause(validation, this.proxy);
+    return this;
+  }
+
+  select<Response>(selectFn: (shape: Shape) => Response) {
+    return new SelectQueryFactory(
+      this.originalValue.constructor as typeof Shape,
+      selectFn,
+      undefined,
+      this.getPropertyPath(),
+    );
+  }
+
+  as(shapeClass: typeof Shape) {
+    return QueryShapeSet.create(new shapeClass(), this.property, this.subject);
+  }
+
+  size() {
+    return new QueryCount(this);
+  }
+}
+
+export class QueryCount {
+  constructor(private source: QueryBuilderObject) {}
+
+  getPropertyPath(): QueryPropertyPath {
+    return [
+      {
+        count: this.source.getPropertyPath(),
+      },
+    ];
+  }
+}
+
+export class WhereBuilder {
+  constructor(
+    public firstPath: WherePath,
+    public andOr: AndOrQueryToken[] = [],
+  ) {}
+
+  and(path: Evaluation | WhereBuilder) {
+    this.andOr.push({and: getWherePath(path)});
+    return this;
+  }
+
+  or(path: Evaluation | WhereBuilder) {
+    this.andOr.push({or: getWherePath(path)});
+    return this;
+  }
+
+  getWherePath(): WhereAndOr {
+    return {
+      firstPath: this.firstPath,
+      andOr: this.andOr,
+    };
+  }
+}
+
+export class Evaluation {
+  constructor(private wherePath: WherePath) {}
+
+  and(path: Evaluation | WhereBuilder) {
+    return new WhereBuilder(this.wherePath).and(path);
+  }
+
+  or(path: Evaluation | WhereBuilder) {
+    return new WhereBuilder(this.wherePath).or(path);
+  }
+
+  getWherePath() {
+    return this.wherePath;
+  }
+}
+
+const getWherePath = (path: Evaluation | WhereBuilder) =>
+  path instanceof WhereBuilder ? path.getWherePath() : path.getWherePath();
+
+const processWhereClause = (
+  validation: (value: QueryBuilderObject) => Evaluation | WhereBuilder,
+  subject: QueryBuilderObject,
+): WherePath => {
+  const result = validation(subject);
+  return getWherePath(result);
+};
 
 export class SelectQueryFactory<S extends Shape> {
   private traceResponse?: unknown;
   limit?: number;
   offset?: number;
   singleResult?: boolean;
+  private wherePath?: WherePath;
+  private sortResponse?: unknown;
+  private sortDirection?: string;
 
   constructor(
     public shape: typeof Shape,
     private queryBuildFn?: (shape: S) => unknown,
     private subject?: S,
+    private parentQueryPath?: QueryPropertyPath,
   ) {
     this.traceResponse = this.getQueryShape();
   }
@@ -124,33 +359,132 @@ export class SelectQueryFactory<S extends Shape> {
     return this.queryBuildFn(queryShape as unknown as S);
   }
 
-  getQueryPaths(): QueryPropertyPath[] {
-    const queryPaths: QueryPropertyPath[] = [];
-    const response = this.traceResponse;
+  getQueryPaths(response = this.traceResponse): QueryPath[] | CustomQueryObject {
+    let queryPaths: QueryPath[] = [];
+    let queryObject: CustomQueryObject | undefined;
 
-    if (response instanceof QueryBuilderObject) {
+    if (
+      response instanceof QueryBuilderObject ||
+      response instanceof QueryCount
+    ) {
       queryPaths.push(response.getPropertyPath());
     } else if (Array.isArray(response)) {
       response.forEach((endValue) => {
         if (endValue instanceof QueryBuilderObject) {
           queryPaths.push(endValue.getPropertyPath());
+        } else if (endValue instanceof QueryCount) {
+          queryPaths.push(endValue.getPropertyPath());
+        } else if (endValue instanceof SelectQueryFactory) {
+          queryPaths.push(endValue.getQueryPaths() as unknown as QueryPath);
+        }
+      });
+    } else if (response instanceof Evaluation || response instanceof WhereBuilder) {
+      queryPaths.push(getWherePath(response));
+    } else if (response instanceof SelectQueryFactory) {
+      queryPaths.push(response.getQueryPaths() as unknown as QueryPath);
+    } else if (typeof response === 'object' && response) {
+      queryObject = {};
+      Object.getOwnPropertyNames(response).forEach((key) => {
+        const value = response[key];
+        if (value instanceof QueryBuilderObject) {
+          queryObject[key] = value.getPropertyPath();
+        } else if (value instanceof QueryCount) {
+          queryObject[key] = value.getPropertyPath();
+        } else if (value instanceof Evaluation || value instanceof WhereBuilder) {
+          queryObject[key] = getWherePath(value);
+        } else {
+          throw new Error(`Unknown trace response type for key ${key}`);
         }
       });
     }
 
-    return queryPaths;
+    if (this.parentQueryPath) {
+      queryPaths = [
+        ...(this.parentQueryPath as unknown as QueryPath[]),
+        (queryObject ?? queryPaths) as QueryPath,
+      ];
+      queryObject = undefined;
+    }
+
+    return queryObject ?? queryPaths;
   }
 
   getQueryObject(): SelectQuery<S> {
     const queryPaths = this.getQueryPaths();
     return {
       type: 'select',
-      select: queryPaths,
+      select: Array.isArray(queryPaths) ? queryPaths : [queryPaths],
+      sortBy: this.getSortByPath(),
       subject: this.subject,
       limit: this.limit,
       offset: this.offset,
       shape: this.shape,
       singleResult: this.singleResult || !!this.subject,
+      where: this.wherePath,
     } as SelectQuery<S>;
+  }
+
+  where(validation: (shape: S) => Evaluation | WhereBuilder) {
+    const dummyShape = new (this.shape as typeof Shape)() as S;
+    const queryShape = QueryShape.create(dummyShape);
+    this.wherePath = processWhereClause(
+      validation as unknown as (
+        value: QueryBuilderObject,
+      ) => Evaluation | WhereBuilder,
+      queryShape,
+    );
+    return this;
+  }
+
+  sortBy<R>(sortFn: (shape: S) => R, direction = 'ASC') {
+    const dummyShape = new (this.shape as typeof Shape)() as S;
+    const queryShape = QueryShape.create(dummyShape);
+    if (sortFn) {
+      this.sortResponse = sortFn(queryShape as unknown as S);
+      this.sortDirection = direction;
+    }
+    return this;
+  }
+
+  setLimit(limit: number) {
+    this.limit = limit;
+    return this;
+  }
+
+  patchResultPromise<ResultType>(promise: Promise<ResultType>) {
+    const patched = promise as Promise<ResultType> & {
+      where?: (validation: (shape: S) => Evaluation | WhereBuilder) => typeof patched;
+      limit?: (limit: number) => typeof patched;
+      one?: () => typeof patched;
+      sortBy?: (sortFn: (shape: S) => unknown, direction?: string) => typeof patched;
+    };
+    patched.where = (validation) => {
+      this.where(validation);
+      return patched;
+    };
+    patched.limit = (limit) => {
+      this.setLimit(limit);
+      return patched;
+    };
+    patched.sortBy = (sortFn, direction) => {
+      this.sortBy(sortFn, direction);
+      return patched;
+    };
+    patched.one = () => {
+      this.setLimit(1);
+      this.singleResult = true;
+      return patched;
+    };
+    return patched;
+  }
+
+  private getSortByPath() {
+    if (!this.sortResponse) {
+      return undefined;
+    }
+    return {
+      paths: this.getQueryPaths(this.sortResponse),
+      direction: this.sortDirection || 'ASC',
+    };
   }
 }

--- a/rebrand/linked-js/src/queries/SelectQuery.ts
+++ b/rebrand/linked-js/src/queries/SelectQuery.ts
@@ -1,0 +1,156 @@
+import {PropertyShape} from '../shapes/PropertyShape.js';
+import {Shape} from '../shapes/Shape.js';
+import {getPropertyShapeByLabel} from '../utils/ShapeClass.js';
+
+export type QueryPropertyPath = QueryStep[];
+
+export type PropertyQueryStep = {
+  property: PropertyShape;
+};
+
+export type QueryStep = PropertyQueryStep;
+
+export type SelectQuery<S = Shape> = {
+  type: 'select';
+  select: QueryPropertyPath[];
+  subject?: S;
+  limit?: number;
+  offset?: number;
+  shape?: typeof Shape;
+  singleResult?: boolean;
+};
+
+export class QueryBuilderObject {
+  constructor(
+    public property?: PropertyShape,
+    public subject?: QueryBuilderObject,
+  ) {}
+
+  getPropertyStep(): QueryStep {
+    return {
+      property: this.property,
+    };
+  }
+
+  getPropertyPath(currentPath?: QueryPropertyPath): QueryPropertyPath {
+    const path: QueryPropertyPath = currentPath ? [...currentPath] : [];
+    if (this.property) {
+      path.unshift(this.getPropertyStep());
+    }
+    if (this.subject) {
+      return this.subject.getPropertyPath(path);
+    }
+    return path;
+  }
+
+  static generatePathValue(
+    propertyShape: PropertyShape,
+    subject: QueryBuilderObject,
+  ) {
+    if (propertyShape.shape) {
+      const shapeClass = propertyShape.shape as typeof Shape;
+      return QueryShape.create(new shapeClass(), propertyShape, subject);
+    }
+    return new QueryValue(propertyShape, subject);
+  }
+}
+
+export class QueryValue extends QueryBuilderObject {}
+
+export class QueryShape extends QueryBuilderObject {
+  private proxy: QueryShape;
+
+  constructor(
+    public originalValue: Shape,
+    property?: PropertyShape,
+    subject?: QueryBuilderObject,
+  ) {
+    super(property, subject);
+  }
+
+  static create(
+    original: Shape,
+    property?: PropertyShape,
+    subject?: QueryBuilderObject,
+  ) {
+    const instance = new QueryShape(original, property, subject);
+    return this.proxifyQueryShape(instance);
+  }
+
+  private static proxifyQueryShape<T extends Shape>(queryShape: QueryShape) {
+    queryShape.proxy = new Proxy(queryShape, {
+      get(target, key) {
+        if (typeof key === 'string') {
+          if (key in queryShape) {
+            const value = (target as any)[key];
+            return typeof value === 'function' ? value.bind(target) : value;
+          }
+
+          const propertyShape = getPropertyShapeByLabel(
+            queryShape.originalValue.constructor as typeof Shape,
+            key,
+          );
+          if (propertyShape) {
+            return QueryBuilderObject.generatePathValue(propertyShape, target);
+          }
+        }
+        return undefined;
+      },
+    });
+    return queryShape.proxy;
+  }
+}
+
+export class SelectQueryFactory<S extends Shape> {
+  private traceResponse?: unknown;
+  limit?: number;
+  offset?: number;
+  singleResult?: boolean;
+
+  constructor(
+    public shape: typeof Shape,
+    private queryBuildFn?: (shape: S) => unknown,
+    private subject?: S,
+  ) {
+    this.traceResponse = this.getQueryShape();
+  }
+
+  private getQueryShape() {
+    if (!this.queryBuildFn) {
+      return undefined;
+    }
+    const dummyShape = new (this.shape as typeof Shape)() as S;
+    const queryShape = QueryShape.create(dummyShape);
+    return this.queryBuildFn(queryShape as unknown as S);
+  }
+
+  getQueryPaths(): QueryPropertyPath[] {
+    const queryPaths: QueryPropertyPath[] = [];
+    const response = this.traceResponse;
+
+    if (response instanceof QueryBuilderObject) {
+      queryPaths.push(response.getPropertyPath());
+    } else if (Array.isArray(response)) {
+      response.forEach((endValue) => {
+        if (endValue instanceof QueryBuilderObject) {
+          queryPaths.push(endValue.getPropertyPath());
+        }
+      });
+    }
+
+    return queryPaths;
+  }
+
+  getQueryObject(): SelectQuery<S> {
+    const queryPaths = this.getQueryPaths();
+    return {
+      type: 'select',
+      select: queryPaths,
+      subject: this.subject,
+      limit: this.limit,
+      offset: this.offset,
+      shape: this.shape,
+      singleResult: this.singleResult || !!this.subject,
+    } as SelectQuery<S>;
+  }
+}

--- a/rebrand/linked-js/src/queries/UpdateQuery.ts
+++ b/rebrand/linked-js/src/queries/UpdateQuery.ts
@@ -1,0 +1,38 @@
+import {Shape} from '../shapes/Shape.js';
+import type {QResult} from './SelectQuery.js';
+import type {NodeShape} from '../shapes/ShapeDefinition.js';
+import {MutationQueryFactory, NodeDescriptionValue, NodeId} from './MutationQuery.js';
+
+export type UpdateQuery<ResponseType = null> = {
+  type: 'update';
+  id: string;
+  shape: QResult<NodeShape>;
+  updates: NodeDescriptionValue;
+};
+
+export class UpdateQueryFactory<ShapeType extends Shape> extends MutationQueryFactory {
+  readonly id: string;
+  readonly updates: NodeDescriptionValue;
+
+  constructor(
+    public shapeClass: typeof Shape,
+    id: NodeId,
+    updateObject: Record<string, unknown>,
+  ) {
+    super();
+    this.id = this.convertNodeReference(id).id;
+    this.updates = this.convertUpdateObject(
+      updateObject,
+      this.shapeClass.shape,
+    );
+  }
+
+  getQueryObject(): UpdateQuery {
+    return {
+      type: 'update',
+      id: this.id,
+      shape: this.shapeClass.shape,
+      updates: this.updates,
+    };
+  }
+}

--- a/rebrand/linked-js/src/shapes/PropertyShape.ts
+++ b/rebrand/linked-js/src/shapes/PropertyShape.ts
@@ -1,19 +1,92 @@
+import type {QResult} from '../queries/SelectQuery.js';
+import type {Shape} from './Shape.js';
+
+export type NodeRef = {id: string};
+
 export type PropertyShapeConfig<ShapeType> = {
-  path: string;
+  path: string | NodeRef;
   maxCount?: number;
-  shape?: ShapeType;
+  minCount?: number;
+  datatype?: string | NodeRef;
+  nodeKind?: string | NodeRef;
+  shape?: ShapeType | string | NodeRef;
+  name?: string;
+  description?: string;
+  required?: boolean;
+};
+
+export type PropertyShapeResult = QResult<null, {
+  path: NodeRef | NodeRef[];
+  minCount?: number;
+  maxCount?: number;
+  datatype?: NodeRef;
+  nodeKind?: NodeRef;
+  name?: string;
+  description?: string;
+  shape?: NodeRef;
+}>;
+
+const toNodeRef = (value: string | NodeRef): NodeRef => {
+  if (typeof value === 'string') {
+    return {id: value};
+  }
+  return value;
 };
 
 export class PropertyShape<ShapeType = unknown> {
   label: string;
-  path: string;
+  path: NodeRef;
   maxCount?: number;
-  shape?: ShapeType;
+  minCount?: number;
+  datatype?: NodeRef;
+  nodeKind?: NodeRef;
+  name?: string;
+  description?: string;
+  shape?: ShapeType | string | NodeRef;
+  valueShapeClass?: typeof Shape;
+  id: string;
 
   constructor(label: string, config: PropertyShapeConfig<ShapeType>) {
     this.label = label;
-    this.path = config.path;
+    this.path = toNodeRef(config.path);
     this.maxCount = config.maxCount;
-    this.shape = config.shape;
+    this.minCount = config.required ? 1 : config.minCount;
+    this.datatype = config.datatype ? toNodeRef(config.datatype) : undefined;
+    this.nodeKind = config.nodeKind ? toNodeRef(config.nodeKind) : undefined;
+    if (config.shape) {
+      if (typeof config.shape === 'function') {
+        this.valueShapeClass = config.shape as unknown as typeof Shape;
+        if (this.valueShapeClass.shape?.id) {
+          this.shape = {id: this.valueShapeClass.shape.id};
+        } else {
+          this.shape = config.shape as ShapeType;
+        }
+      } else if (typeof config.shape === 'string') {
+        this.shape = {id: config.shape} as NodeRef;
+      } else {
+        this.shape = config.shape;
+      }
+    }
+    this.name = config.name;
+    this.description = config.description;
+  }
+
+  getResult(): PropertyShapeResult {
+    return {
+      id: this.id,
+      path: this.path,
+      minCount: this.minCount,
+      maxCount: this.maxCount,
+      datatype: this.datatype,
+      nodeKind: this.nodeKind,
+      name: this.name,
+      description: this.description,
+      shape:
+        this.shape && typeof this.shape === 'object' && 'id' in this.shape
+          ? (this.shape as NodeRef)
+          : this.shape
+            ? toNodeRef(this.shape as string)
+            : undefined,
+    };
   }
 }

--- a/rebrand/linked-js/src/shapes/PropertyShape.ts
+++ b/rebrand/linked-js/src/shapes/PropertyShape.ts
@@ -1,0 +1,19 @@
+export type PropertyShapeConfig<ShapeType> = {
+  path: string;
+  maxCount?: number;
+  shape?: ShapeType;
+};
+
+export class PropertyShape<ShapeType = unknown> {
+  label: string;
+  path: string;
+  maxCount?: number;
+  shape?: ShapeType;
+
+  constructor(label: string, config: PropertyShapeConfig<ShapeType>) {
+    this.label = label;
+    this.path = config.path;
+    this.maxCount = config.maxCount;
+    this.shape = config.shape;
+  }
+}

--- a/rebrand/linked-js/src/shapes/Shape.ts
+++ b/rebrand/linked-js/src/shapes/Shape.ts
@@ -1,19 +1,68 @@
+import {CreateQueryFactory} from '../queries/CreateQuery.js';
+import {DeleteQueryFactory} from '../queries/DeleteQuery.js';
 import {SelectQueryFactory} from '../queries/SelectQuery.js';
+import {UpdateQueryFactory} from '../queries/UpdateQuery.js';
 import type {IQueryParser} from '../interfaces/IQueryParser.js';
-import {ShapeDefinition} from './ShapeDefinition.js';
+import {NodeShape} from './ShapeDefinition.js';
 
 export class Shape {
   static queryParser: IQueryParser;
-  static shape: ShapeDefinition;
+  static shape: NodeShape;
 
   static select<ShapeType extends Shape, ResultType = unknown[]>(
     this: {new (): ShapeType; queryParser: IQueryParser},
+    subjectOrSelectFn?: ShapeType | {id: string} | ((shape: ShapeType) => unknown),
     selectFn?: (shape: ShapeType) => unknown,
   ): Promise<ResultType> {
+    const subject =
+      typeof subjectOrSelectFn === 'function' || !subjectOrSelectFn
+        ? undefined
+        : subjectOrSelectFn;
+    const queryBuildFn =
+      typeof subjectOrSelectFn === 'function' ? subjectOrSelectFn : selectFn;
     const query = new SelectQueryFactory(
       this as unknown as typeof Shape,
-      selectFn,
+      queryBuildFn,
+      subject as ShapeType,
     );
-    return this.queryParser.selectQuery(query as SelectQueryFactory<ShapeType>);
+    const result = this.queryParser.selectQuery(
+      query as SelectQueryFactory<ShapeType>,
+    );
+    return query.patchResultPromise(result) as Promise<ResultType>;
+  }
+
+  static create<ShapeType extends Shape, ResultType = unknown>(
+    this: {new (): ShapeType; queryParser: IQueryParser},
+    updateObject: Record<string, unknown>,
+  ): Promise<ResultType> {
+    const query = new CreateQueryFactory(
+      this as unknown as typeof Shape,
+      updateObject,
+    );
+    return this.queryParser.createQuery(query as CreateQueryFactory<ShapeType>);
+  }
+
+  static update<ShapeType extends Shape, ResultType = unknown>(
+    this: {new (): ShapeType; queryParser: IQueryParser},
+    id: {id: string} | {uri: string} | string,
+    updateObject: Record<string, unknown>,
+  ): Promise<ResultType> {
+    const query = new UpdateQueryFactory(
+      this as unknown as typeof Shape,
+      id,
+      updateObject,
+    );
+    return this.queryParser.updateQuery(query as UpdateQueryFactory<ShapeType>);
+  }
+
+  static delete<ShapeType extends Shape, ResultType = unknown>(
+    this: {new (): ShapeType; queryParser: IQueryParser},
+    ids: {id: string} | {uri: string} | string | Array<{id: string} | {uri: string} | string>,
+  ): Promise<ResultType> {
+    const query = new DeleteQueryFactory(
+      this as unknown as typeof Shape,
+      ids,
+    );
+    return this.queryParser.deleteQuery(query as DeleteQueryFactory<ShapeType>);
   }
 }

--- a/rebrand/linked-js/src/shapes/Shape.ts
+++ b/rebrand/linked-js/src/shapes/Shape.ts
@@ -1,0 +1,19 @@
+import {SelectQueryFactory} from '../queries/SelectQuery.js';
+import type {IQueryParser} from '../interfaces/IQueryParser.js';
+import {ShapeDefinition} from './ShapeDefinition.js';
+
+export class Shape {
+  static queryParser: IQueryParser;
+  static shape: ShapeDefinition;
+
+  static select<ShapeType extends Shape, ResultType = unknown[]>(
+    this: {new (): ShapeType; queryParser: IQueryParser},
+    selectFn?: (shape: ShapeType) => unknown,
+  ): Promise<ResultType> {
+    const query = new SelectQueryFactory(
+      this as unknown as typeof Shape,
+      selectFn,
+    );
+    return this.queryParser.selectQuery(query as SelectQueryFactory<ShapeType>);
+  }
+}

--- a/rebrand/linked-js/src/shapes/Shape.ts
+++ b/rebrand/linked-js/src/shapes/Shape.ts
@@ -1,34 +1,95 @@
 import {CreateQueryFactory} from '../queries/CreateQuery.js';
 import {DeleteQueryFactory} from '../queries/DeleteQuery.js';
-import {SelectQueryFactory} from '../queries/SelectQuery.js';
+import {
+  GetQueryResponseType,
+  PatchedQueryPromise,
+  QResult,
+  QShape,
+  QueryResponseToResultType,
+  SelectQueryFactory,
+} from '../queries/SelectQuery.js';
 import {UpdateQueryFactory} from '../queries/UpdateQuery.js';
 import type {IQueryParser} from '../interfaces/IQueryParser.js';
 import {NodeShape} from './ShapeDefinition.js';
 
 export class Shape {
+  declare protected __shapeBrand: void;
   static queryParser: IQueryParser;
   static shape: NodeShape;
 
-  static select<ShapeType extends Shape, ResultType = unknown[]>(
+  static select<
+    ShapeType extends Shape,
+    S = unknown,
+    ResultType = QueryResponseToResultType<S, ShapeType>[],
+  >(
     this: {new (): ShapeType; queryParser: IQueryParser},
-    subjectOrSelectFn?: ShapeType | {id: string} | ((shape: ShapeType) => unknown),
-    selectFn?: (shape: ShapeType) => unknown,
-  ): Promise<ResultType> {
-    const subject =
-      typeof subjectOrSelectFn === 'function' || !subjectOrSelectFn
-        ? undefined
-        : subjectOrSelectFn;
-    const queryBuildFn =
-      typeof subjectOrSelectFn === 'function' ? subjectOrSelectFn : selectFn;
-    const query = new SelectQueryFactory(
-      this as unknown as typeof Shape,
-      queryBuildFn,
+    selectFn: (shape: QShape<ShapeType>) => S,
+  ): PatchedQueryPromise<ResultType, ShapeType>;
+  static select<
+    ShapeType extends Shape,
+    S = unknown,
+    ResultType = QueryResponseToResultType<
+      GetQueryResponseType<SelectQueryFactory<ShapeType, S>>,
+      ShapeType
+    >[],
+  >(this: {
+    new (): ShapeType;
+    queryParser: IQueryParser;
+  }): PatchedQueryPromise<ResultType, ShapeType>;
+  static select<
+    ShapeType extends Shape,
+    S = unknown,
+    ResultType = QueryResponseToResultType<
+      GetQueryResponseType<SelectQueryFactory<ShapeType, S>>,
+      ShapeType
+    >,
+  >(
+    this: {new (): ShapeType; queryParser: IQueryParser},
+    subjects?: ShapeType | QResult<ShapeType>,
+    selectFn?: (shape: QShape<ShapeType>) => S,
+  ): PatchedQueryPromise<ResultType, ShapeType>;
+  static select<
+    ShapeType extends Shape,
+    S = unknown,
+    ResultType = QueryResponseToResultType<
+      GetQueryResponseType<SelectQueryFactory<ShapeType, S>>,
+      ShapeType
+    >[],
+  >(
+    this: {new (): ShapeType; queryParser: IQueryParser},
+    subjects?: ShapeType[] | QResult<ShapeType>[],
+    selectFn?: (shape: QShape<ShapeType>) => S,
+  ): PatchedQueryPromise<ResultType, ShapeType>;
+  static select<
+    ShapeType extends Shape,
+    S = unknown,
+    ResultType = QueryResponseToResultType<
+      GetQueryResponseType<SelectQueryFactory<ShapeType, S>>,
+      ShapeType
+    >[],
+  >(
+    this: {new (): ShapeType; queryParser: IQueryParser},
+    targetOrSelectFn?: ShapeType | ((shape: QShape<ShapeType>) => S),
+    selectFn?: (shape: QShape<ShapeType>) => S,
+  ): PatchedQueryPromise<ResultType, ShapeType> {
+    let _selectFn;
+    let subject;
+    if (selectFn) {
+      _selectFn = selectFn;
+      subject = targetOrSelectFn;
+    } else {
+      _selectFn = targetOrSelectFn;
+    }
+
+    const query = new SelectQueryFactory<ShapeType, S>(
+      this as unknown as {new (): ShapeType},
+      _selectFn,
       subject as ShapeType,
     );
     const result = this.queryParser.selectQuery(
-      query as SelectQueryFactory<ShapeType>,
-    );
-    return query.patchResultPromise(result) as Promise<ResultType>;
+      query as SelectQueryFactory<ShapeType, S>,
+    ) as Promise<ResultType>;
+    return query.patchResultPromise(result);
   }
 
   static create<ShapeType extends Shape, ResultType = unknown>(

--- a/rebrand/linked-js/src/shapes/ShapeDefinition.ts
+++ b/rebrand/linked-js/src/shapes/ShapeDefinition.ts
@@ -1,0 +1,13 @@
+import {PropertyShape} from './PropertyShape.js';
+
+export class ShapeDefinition {
+  private propertyShapes: PropertyShape[] = [];
+
+  addPropertyShape(propertyShape: PropertyShape) {
+    this.propertyShapes.push(propertyShape);
+  }
+
+  getPropertyShapes(): PropertyShape[] {
+    return this.propertyShapes;
+  }
+}

--- a/rebrand/linked-js/src/shapes/ShapeDefinition.ts
+++ b/rebrand/linked-js/src/shapes/ShapeDefinition.ts
@@ -1,13 +1,32 @@
-import {PropertyShape} from './PropertyShape.js';
+import {PropertyShape, PropertyShapeResult} from './PropertyShape.js';
+import {sanitizeUriFragment} from './shacl.js';
 
-export class ShapeDefinition {
+export type NodeRef = {id: string};
+
+export class NodeShape {
+  id: string;
+  label?: string;
+  targetClass?: NodeRef;
   private propertyShapes: PropertyShape[] = [];
 
+  constructor(options?: {id?: string; label?: string; targetClass?: NodeRef}) {
+    this.id = options?.id;
+    this.label = options?.label;
+    this.targetClass = options?.targetClass;
+  }
+
   addPropertyShape(propertyShape: PropertyShape) {
+    if (this.id && !propertyShape.id) {
+      propertyShape.id = `${this.id}/${sanitizeUriFragment(propertyShape.label)}`;
+    }
     this.propertyShapes.push(propertyShape);
   }
 
   getPropertyShapes(): PropertyShape[] {
     return this.propertyShapes;
+  }
+
+  get properties(): PropertyShapeResult[] {
+    return this.propertyShapes.map((shape) => shape.getResult());
   }
 }

--- a/rebrand/linked-js/src/shapes/decorators.ts
+++ b/rebrand/linked-js/src/shapes/decorators.ts
@@ -2,11 +2,16 @@ import {PropertyShape, PropertyShapeConfig} from './PropertyShape.js';
 import {Shape} from './Shape.js';
 import {NodeShape} from './ShapeDefinition.js';
 import {getNodeShapeUri, LINCD_DATA_ROOT, sanitizeUriFragment} from './shacl.js';
+import {registerShapeClass} from '../utils/ShapeClass.js';
 
 type PropertyDecoratorConfig<ShapeType> = PropertyShapeConfig<ShapeType>;
 
 const ensureShape = (shapeClass: typeof Shape) => {
-  if (!shapeClass.shape) {
+  const hasOwnShape = Object.prototype.hasOwnProperty.call(
+    shapeClass,
+    'shape',
+  );
+  if (!hasOwnShape || !shapeClass.shape) {
     const packageName = (shapeClass as any).packageName || 'default';
     const shapeName = shapeClass.name;
     const id = getNodeShapeUri(packageName, shapeName);
@@ -14,6 +19,7 @@ const ensureShape = (shapeClass: typeof Shape) => {
       id,
       label: shapeName,
     });
+    registerShapeClass(shapeClass);
   }
 };
 
@@ -23,6 +29,7 @@ export const linkedShape = <T extends typeof Shape>(shapeClass: T): T => {
   const newId = getNodeShapeUri(packageName, shapeClass.name);
   if (shapeClass.shape.id !== newId) {
     shapeClass.shape.id = newId;
+    registerShapeClass(shapeClass);
     shapeClass.shape.getPropertyShapes().forEach((propertyShape) => {
       propertyShape.id = `${newId}/${sanitizeUriFragment(propertyShape.label)}`;
       if (propertyShape.valueShapeClass?.shape?.id) {
@@ -30,6 +37,7 @@ export const linkedShape = <T extends typeof Shape>(shapeClass: T): T => {
       }
     });
   }
+  registerShapeClass(shapeClass);
   return shapeClass;
 };
 

--- a/rebrand/linked-js/src/shapes/decorators.ts
+++ b/rebrand/linked-js/src/shapes/decorators.ts
@@ -1,17 +1,35 @@
 import {PropertyShape, PropertyShapeConfig} from './PropertyShape.js';
 import {Shape} from './Shape.js';
-import {ShapeDefinition} from './ShapeDefinition.js';
+import {NodeShape} from './ShapeDefinition.js';
+import {getNodeShapeUri, LINCD_DATA_ROOT, sanitizeUriFragment} from './shacl.js';
 
 type PropertyDecoratorConfig<ShapeType> = PropertyShapeConfig<ShapeType>;
 
-const ensureShapeDefinition = (shapeClass: typeof Shape) => {
+const ensureShape = (shapeClass: typeof Shape) => {
   if (!shapeClass.shape) {
-    shapeClass.shape = new ShapeDefinition();
+    const packageName = (shapeClass as any).packageName || 'default';
+    const shapeName = shapeClass.name;
+    const id = getNodeShapeUri(packageName, shapeName);
+    shapeClass.shape = new NodeShape({
+      id,
+      label: shapeName,
+    });
   }
 };
 
 export const linkedShape = <T extends typeof Shape>(shapeClass: T): T => {
-  ensureShapeDefinition(shapeClass);
+  ensureShape(shapeClass);
+  const packageName = (shapeClass as any).packageName || 'default';
+  const newId = getNodeShapeUri(packageName, shapeClass.name);
+  if (shapeClass.shape.id !== newId) {
+    shapeClass.shape.id = newId;
+    shapeClass.shape.getPropertyShapes().forEach((propertyShape) => {
+      propertyShape.id = `${newId}/${sanitizeUriFragment(propertyShape.label)}`;
+      if (propertyShape.valueShapeClass?.shape?.id) {
+        propertyShape.shape = {id: propertyShape.valueShapeClass.shape.id};
+      }
+    });
+  }
   return shapeClass;
 };
 
@@ -20,9 +38,13 @@ export const literalProperty = <ShapeType = unknown>(
 ) => {
   return (target: Shape, propertyKey: string) => {
     const shapeClass = target.constructor as typeof Shape;
-    ensureShapeDefinition(shapeClass);
+    ensureShape(shapeClass);
+    const propertyShape = new PropertyShape(propertyKey, config);
+    propertyShape.id = `${shapeClass.shape.id}/${sanitizeUriFragment(
+      propertyKey,
+    )}`;
     shapeClass.shape.addPropertyShape(
-      new PropertyShape(propertyKey, config),
+      propertyShape,
     );
   };
 };
@@ -32,9 +54,13 @@ export const objectProperty = <ShapeType = unknown>(
 ) => {
   return (target: Shape, propertyKey: string) => {
     const shapeClass = target.constructor as typeof Shape;
-    ensureShapeDefinition(shapeClass);
+    ensureShape(shapeClass);
+    const propertyShape = new PropertyShape(propertyKey, config);
+    propertyShape.id = `${shapeClass.shape.id}/${sanitizeUriFragment(
+      propertyKey,
+    )}`;
     shapeClass.shape.addPropertyShape(
-      new PropertyShape(propertyKey, config),
+      propertyShape,
     );
   };
 };

--- a/rebrand/linked-js/src/shapes/decorators.ts
+++ b/rebrand/linked-js/src/shapes/decorators.ts
@@ -1,0 +1,40 @@
+import {PropertyShape, PropertyShapeConfig} from './PropertyShape.js';
+import {Shape} from './Shape.js';
+import {ShapeDefinition} from './ShapeDefinition.js';
+
+type PropertyDecoratorConfig<ShapeType> = PropertyShapeConfig<ShapeType>;
+
+const ensureShapeDefinition = (shapeClass: typeof Shape) => {
+  if (!shapeClass.shape) {
+    shapeClass.shape = new ShapeDefinition();
+  }
+};
+
+export const linkedShape = <T extends typeof Shape>(shapeClass: T): T => {
+  ensureShapeDefinition(shapeClass);
+  return shapeClass;
+};
+
+export const literalProperty = <ShapeType = unknown>(
+  config: PropertyDecoratorConfig<ShapeType>,
+) => {
+  return (target: Shape, propertyKey: string) => {
+    const shapeClass = target.constructor as typeof Shape;
+    ensureShapeDefinition(shapeClass);
+    shapeClass.shape.addPropertyShape(
+      new PropertyShape(propertyKey, config),
+    );
+  };
+};
+
+export const objectProperty = <ShapeType = unknown>(
+  config: PropertyDecoratorConfig<ShapeType>,
+) => {
+  return (target: Shape, propertyKey: string) => {
+    const shapeClass = target.constructor as typeof Shape;
+    ensureShapeDefinition(shapeClass);
+    shapeClass.shape.addPropertyShape(
+      new PropertyShape(propertyKey, config),
+    );
+  };
+};

--- a/rebrand/linked-js/src/shapes/shacl.ts
+++ b/rebrand/linked-js/src/shapes/shacl.ts
@@ -1,0 +1,15 @@
+export const LINCD_DATA_ROOT = 'https://data.lincd.org/';
+
+export const sanitizeUriFragment = (value: string) => {
+  if (!value) return value;
+  return value
+    .replace(/\u200B/g, '')
+    .replace(/[^\w]+/g, '-')
+    .toLowerCase();
+};
+
+export const getNodeShapeUri = (packageName: string, shapeName: string) => {
+  return `${LINCD_DATA_ROOT}module/${sanitizeUriFragment(
+    packageName,
+  )}/shape/${sanitizeUriFragment(shapeName)}`;
+};

--- a/rebrand/linked-js/src/test-helpers/query-fixtures.ts
+++ b/rebrand/linked-js/src/test-helpers/query-fixtures.ts
@@ -1,0 +1,63 @@
+import {linkedShape, literalProperty, objectProperty} from '../package.js';
+import {Shape} from '../shapes/Shape.js';
+
+export const name = 'name';
+export const bestFriend = 'bestFriend';
+export const friends = 'friends';
+export const pets = 'pets';
+export const firstPet = 'firstPet';
+export const hobby = 'hobby';
+export const birthDate = 'birthDate';
+export const isRealPerson = 'isRealPerson';
+export const guardDogLevel = 'guardDogLevel';
+
+@linkedShape
+class Pet extends Shape {}
+
+@linkedShape
+class Dog extends Pet {
+  @literalProperty({path: guardDogLevel, maxCount: 1})
+  declare guardDogLevel: number;
+}
+
+@linkedShape
+class Person extends Shape {
+  @literalProperty({path: name, maxCount: 1})
+  declare name: string;
+
+  @objectProperty({path: bestFriend, maxCount: 1, shape: Person})
+  declare bestFriend: Person;
+
+  @objectProperty({path: friends, shape: Person})
+  declare friends: Person;
+
+  @objectProperty({path: pets, shape: Pet})
+  declare pets: Pet;
+
+  @objectProperty({path: firstPet, shape: Pet, maxCount: 1})
+  declare firstPet: Pet;
+
+  @literalProperty({path: hobby, maxCount: 1})
+  declare hobby: string;
+
+  @literalProperty({path: birthDate, maxCount: 1})
+  declare birthDate: Date;
+
+  @literalProperty({path: isRealPerson, maxCount: 1})
+  declare isRealPerson: boolean;
+}
+
+export const queryTestFixtures = {
+  Pet,
+  Dog,
+  Person,
+  name,
+  bestFriend,
+  friends,
+  pets,
+  firstPet,
+  hobby,
+  birthDate,
+  isRealPerson,
+  guardDogLevel,
+};

--- a/rebrand/linked-js/src/test-helpers/query-fixtures.ts
+++ b/rebrand/linked-js/src/test-helpers/query-fixtures.ts
@@ -44,10 +44,10 @@ class Person extends Shape {
   declare bestFriend: Person;
 
   @objectProperty({path: friends, shape: Person})
-  declare friends: Person;
+  declare friends: Person[];
 
   @objectProperty({path: pets, shape: Pet})
-  declare pets: Pet;
+  declare pets: Pet[];
 
   @objectProperty({path: firstPet, shape: Pet, maxCount: 1})
   declare firstPet: Pet;
@@ -64,7 +64,28 @@ class Person extends Shape {
 
 Person.shape.targetClass = {id: personClass};
 
-export const queryTestFixtures = {
+export type QueryTestFixtures = {
+  Pet: typeof Pet;
+  Dog: typeof Dog;
+  Person: typeof Person;
+  name: string;
+  bestFriend: string;
+  friends: string;
+  pets: string;
+  firstPet: string;
+  hobby: string;
+  birthDate: string;
+  isRealPerson: string;
+  guardDogLevel: string;
+  personClass: string;
+  petClass: string;
+  dogClass: string;
+  xsdDateTime: string;
+  xsdBoolean: string;
+  xsdInteger: string;
+};
+
+export const queryTestFixtures: QueryTestFixtures = {
   Pet,
   Dog,
   Person,

--- a/rebrand/linked-js/src/test-helpers/query-fixtures.ts
+++ b/rebrand/linked-js/src/test-helpers/query-fixtures.ts
@@ -1,24 +1,39 @@
 import {linkedShape, literalProperty, objectProperty} from '../package.js';
 import {Shape} from '../shapes/Shape.js';
 
-export const name = 'name';
-export const bestFriend = 'bestFriend';
-export const friends = 'friends';
-export const pets = 'pets';
-export const firstPet = 'firstPet';
-export const hobby = 'hobby';
-export const birthDate = 'birthDate';
-export const isRealPerson = 'isRealPerson';
-export const guardDogLevel = 'guardDogLevel';
+const tempBase = 'lin://tmp/';
+const xsdBase = 'http://www.w3.org/2001/XMLSchema#';
+
+export const name = `${tempBase}name`;
+export const bestFriend = `${tempBase}bestFriend`;
+export const friends = `${tempBase}friends`;
+export const pets = `${tempBase}pets`;
+export const firstPet = `${tempBase}firstPet`;
+export const hobby = `${tempBase}hobby`;
+export const birthDate = `${tempBase}birthDate`;
+export const isRealPerson = `${tempBase}isRealPerson`;
+export const guardDogLevel = `${tempBase}guardDogLevel`;
+
+export const personClass = `${tempBase}Person`;
+export const petClass = `${tempBase}Pet`;
+export const dogClass = `${tempBase}Dog`;
+
+export const xsdDateTime = `${xsdBase}dateTime`;
+export const xsdBoolean = `${xsdBase}boolean`;
+export const xsdInteger = `${xsdBase}integer`;
 
 @linkedShape
 class Pet extends Shape {}
 
+Pet.shape.targetClass = {id: petClass};
+
 @linkedShape
 class Dog extends Pet {
-  @literalProperty({path: guardDogLevel, maxCount: 1})
+  @literalProperty({path: guardDogLevel, maxCount: 1, datatype: xsdInteger})
   declare guardDogLevel: number;
 }
+
+Dog.shape.targetClass = {id: dogClass};
 
 @linkedShape
 class Person extends Shape {
@@ -40,12 +55,14 @@ class Person extends Shape {
   @literalProperty({path: hobby, maxCount: 1})
   declare hobby: string;
 
-  @literalProperty({path: birthDate, maxCount: 1})
+  @literalProperty({path: birthDate, maxCount: 1, datatype: xsdDateTime})
   declare birthDate: Date;
 
-  @literalProperty({path: isRealPerson, maxCount: 1})
+  @literalProperty({path: isRealPerson, maxCount: 1, datatype: xsdBoolean})
   declare isRealPerson: boolean;
 }
+
+Person.shape.targetClass = {id: personClass};
 
 export const queryTestFixtures = {
   Pet,
@@ -60,4 +77,10 @@ export const queryTestFixtures = {
   birthDate,
   isRealPerson,
   guardDogLevel,
+  personClass,
+  petClass,
+  dogClass,
+  xsdDateTime,
+  xsdBoolean,
+  xsdInteger,
 };

--- a/rebrand/linked-js/src/tests/linkedstorage.test.ts
+++ b/rebrand/linked-js/src/tests/linkedstorage.test.ts
@@ -1,0 +1,85 @@
+import {describe, expect, test} from '@jest/globals';
+import {linkedShape, literalProperty, Shape} from '../package.js';
+import {LinkedStorage} from '../utils/LinkedStorage.js';
+
+const name = 'name';
+
+@linkedShape
+class Person extends Shape {
+  @literalProperty({path: name, maxCount: 1})
+  declare name: string;
+}
+
+class DummyStore {
+  lastQuery: any;
+  lastType: string;
+
+  async selectQuery<ResultType>(query): Promise<ResultType> {
+    this.lastQuery = query;
+    this.lastType = 'select';
+    return [] as ResultType;
+  }
+
+  async createQuery<ResultType>(query): Promise<ResultType> {
+    this.lastQuery = query;
+    this.lastType = 'create';
+    return {} as ResultType;
+  }
+
+  async updateQuery<ResultType>(query): Promise<ResultType> {
+    this.lastQuery = query;
+    this.lastType = 'update';
+    return {} as ResultType;
+  }
+
+  async deleteQuery<ResultType>(query): Promise<ResultType> {
+    this.lastQuery = query;
+    this.lastType = 'delete';
+    return {} as ResultType;
+  }
+}
+
+describe('LinkedStorage routing', () => {
+  test('forwards select to default store', async () => {
+    LinkedStorage.reset();
+    const store = new DummyStore();
+    LinkedStorage.setDefaultStore(store);
+
+    await Person.select((p) => p.name);
+
+    expect(store.lastType).toBe('select');
+    expect(store.lastQuery.type).toBe('select');
+  });
+
+  test('routes shape-specific queries to assigned store', async () => {
+    LinkedStorage.reset();
+    const defaultStore = new DummyStore();
+    const specialStore = new DummyStore();
+
+    LinkedStorage.setDefaultStore(defaultStore);
+    LinkedStorage.setStoreForShapes(specialStore, Person);
+
+    await Person.select((p) => p.name);
+
+    expect(specialStore.lastType).toBe('select');
+    expect(defaultStore.lastType).not.toBe('select');
+  });
+
+  test('forwards CRUD queries to default store', async () => {
+    LinkedStorage.reset();
+    const store = new DummyStore();
+    LinkedStorage.setDefaultStore(store);
+
+    await Person.create({name: 'New'});
+    expect(store.lastType).toBe('create');
+    expect(store.lastQuery.type).toBe('create');
+
+    await Person.update('p1', {name: 'Updated'});
+    expect(store.lastType).toBe('update');
+    expect(store.lastQuery.type).toBe('update');
+
+    await Person.delete('p1');
+    expect(store.lastType).toBe('delete');
+    expect(store.lastQuery.type).toBe('delete');
+  });
+});

--- a/rebrand/linked-js/src/tests/package.test.ts
+++ b/rebrand/linked-js/src/tests/package.test.ts
@@ -1,0 +1,39 @@
+import {describe, expect, test} from '@jest/globals';
+import {linkedPackage} from '../utils/Package.js';
+import {linkedShape, literalProperty, Shape} from '../package.js';
+
+describe('linkedPackage', () => {
+  test('registers shapes and utilities', () => {
+    const pkg = linkedPackage('lincd-org');
+
+    @pkg.linkedShape
+    class Person extends Shape {
+      @literalProperty({path: 'name', maxCount: 1})
+      declare name: string;
+    }
+
+    @pkg.linkedUtil
+    class Helper {}
+
+    expect(pkg.packageName).toBe('lincd-org');
+    expect(pkg.packageExports.Person).toBe(Person);
+    expect(pkg.getPackageShape('Person')).toBe(Person);
+    expect(pkg.packageExports.Helper).toBe(Helper);
+    expect(pkg.linkedShape).toBeDefined();
+    expect(linkedShape).toBeDefined();
+  });
+
+  test('registers ontology exports', () => {
+    const pkg = linkedPackage('lincd-org-ontology');
+    class ExampleOntology {}
+
+    pkg.linkedOntology(ExampleOntology, () => null, 'example');
+
+    expect(pkg.packageExports.ExampleOntology).toBe(ExampleOntology);
+  });
+
+  test('linkedComponent is not exposed in linked-js', () => {
+    const pkg = linkedPackage('lincd-react') as Record<string, unknown>;
+    expect(pkg.linkedComponent).toBeUndefined();
+  });
+});

--- a/rebrand/linked-js/src/tests/query-basic.test.ts
+++ b/rebrand/linked-js/src/tests/query-basic.test.ts
@@ -1,0 +1,42 @@
+import {describe, expect, test} from '@jest/globals';
+import {linkedShape, literalProperty, Shape} from '../package.js';
+import {SelectQueryFactory} from '../queries/SelectQuery.js';
+
+const name = 'name';
+
+@linkedShape
+class Person extends Shape {
+  @literalProperty({path: name, maxCount: 1})
+  declare name: string;
+}
+
+class QueryCaptureStore {
+  lastQuery?: ReturnType<SelectQueryFactory<Shape>['getQueryObject']>;
+
+  async selectQuery<ResultType>(query: SelectQueryFactory<Shape>) {
+    this.lastQuery = query.getQueryObject();
+    return [] as ResultType;
+  }
+}
+
+describe('query builder basics', () => {
+  test('selecting a literal property builds a query object', async () => {
+    const store = new QueryCaptureStore();
+    Person.queryParser = store;
+
+    await Person.select((p) => p.name);
+
+    const query = store.lastQuery;
+    const propertyShape = Person.shape.getPropertyShapes()[0];
+
+    expect(query?.type).toBe('select');
+    expect(query?.shape).toBe(Person);
+    expect(query?.subject).toBeUndefined();
+    expect(query?.singleResult).toBe(false);
+    expect(query?.select).toHaveLength(1);
+    expect(query?.select[0]).toHaveLength(1);
+    expect(query?.select[0][0].property).toBe(propertyShape);
+    expect(query?.select[0][0].property.label).toBe('name');
+    expect(query?.select[0][0].property.path).toBe(name);
+  });
+});

--- a/rebrand/linked-js/src/tests/query-basic.test.ts
+++ b/rebrand/linked-js/src/tests/query-basic.test.ts
@@ -1,32 +1,111 @@
 import {describe, expect, test} from '@jest/globals';
-import {linkedShape, literalProperty, Shape} from '../package.js';
+import {linkedShape, literalProperty, objectProperty, Shape} from '../package.js';
+import {CreateQueryFactory} from '../queries/CreateQuery.js';
+import {DeleteQueryFactory} from '../queries/DeleteQuery.js';
 import {SelectQueryFactory} from '../queries/SelectQuery.js';
+import {UpdateQueryFactory} from '../queries/UpdateQuery.js';
 
 const name = 'name';
+const bestFriend = 'bestFriend';
+const friends = 'friends';
+const pets = 'pets';
+const firstPet = 'firstPet';
+const hobby = 'hobby';
+const birthDate = 'birthDate';
+const isRealPerson = 'isRealPerson';
+const guardDogLevel = 'guardDogLevel';
+
+@linkedShape
+class Pet extends Shape {}
+
+@linkedShape
+class Dog extends Pet {
+  @literalProperty({path: guardDogLevel, maxCount: 1})
+  declare guardDogLevel: number;
+}
 
 @linkedShape
 class Person extends Shape {
   @literalProperty({path: name, maxCount: 1})
   declare name: string;
+
+  @objectProperty({path: bestFriend, maxCount: 1, shape: Person})
+  declare bestFriend: Person;
+
+  @objectProperty({path: friends, shape: Person})
+  declare friends: Person;
+
+  @objectProperty({path: pets, shape: Pet})
+  declare pets: Pet;
+
+  @objectProperty({path: firstPet, shape: Pet, maxCount: 1})
+  declare firstPet: Pet;
+
+  @literalProperty({path: hobby, maxCount: 1})
+  declare hobby: string;
+
+  @literalProperty({path: birthDate, maxCount: 1})
+  declare birthDate: Date;
+
+  @literalProperty({path: isRealPerson, maxCount: 1})
+  declare isRealPerson: boolean;
 }
 
 class QueryCaptureStore {
-  lastQuery?: ReturnType<SelectQueryFactory<Shape>['getQueryObject']>;
+  lastQueryFactory?: SelectQueryFactory<Shape>;
+  lastCreate?: CreateQueryFactory<Shape>;
+  lastUpdate?: UpdateQueryFactory<Shape>;
+  lastDelete?: DeleteQueryFactory<Shape>;
 
   async selectQuery<ResultType>(query: SelectQueryFactory<Shape>) {
-    this.lastQuery = query.getQueryObject();
+    this.lastQueryFactory = query;
     return [] as ResultType;
+  }
+
+  async createQuery<ResultType>(query: CreateQueryFactory<Shape>) {
+    this.lastCreate = query;
+    return {} as ResultType;
+  }
+
+  async updateQuery<ResultType>(query: UpdateQueryFactory<Shape>) {
+    this.lastUpdate = query;
+    return {} as ResultType;
+  }
+
+  async deleteQuery<ResultType>(query: DeleteQueryFactory<Shape>) {
+    this.lastDelete = query;
+    return {} as ResultType;
+  }
+
+  getQueryObject() {
+    return this.lastQueryFactory?.getQueryObject();
+  }
+
+  getCreateQuery() {
+    return this.lastCreate?.getQueryObject();
+  }
+
+  getUpdateQuery() {
+    return this.lastUpdate?.getQueryObject();
+  }
+
+  getDeleteQuery() {
+    return this.lastDelete?.getQueryObject();
   }
 }
 
 describe('query builder basics', () => {
-  test('selecting a literal property builds a query object', async () => {
+  const getQuery = async (
+    run: (store: QueryCaptureStore) => Promise<unknown>,
+  ) => {
     const store = new QueryCaptureStore();
     Person.queryParser = store;
+    await run(store);
+    return store.getQueryObject();
+  };
 
-    await Person.select((p) => p.name);
-
-    const query = store.lastQuery;
+  test('selecting a literal property builds a query object', async () => {
+    const query = await getQuery(async () => Person.select((p) => p.name));
     const propertyShape = Person.shape.getPropertyShapes()[0];
 
     expect(query?.type).toBe('select');
@@ -37,6 +116,413 @@ describe('query builder basics', () => {
     expect(query?.select[0]).toHaveLength(1);
     expect(query?.select[0][0].property).toBe(propertyShape);
     expect(query?.select[0][0].property.label).toBe('name');
-    expect(query?.select[0][0].property.path).toBe(name);
+    expect(query?.select[0][0].property.path).toEqual({id: name});
+  });
+
+  test('selecting an object property builds a query object', async () => {
+    const query = await getQuery(async () =>
+      Person.select((p) => p.bestFriend),
+    );
+    const propertyShape = Person.shape
+      .getPropertyShapes()
+      .find((shape) => shape.label === 'bestFriend');
+
+    expect(query?.select).toHaveLength(1);
+    expect(query?.select[0]).toHaveLength(1);
+    expect(query?.select[0][0].property).toBe(propertyShape);
+    expect(query?.select[0][0].property.path).toEqual({id: bestFriend});
+  });
+
+  test('selecting multiple literal properties builds multiple paths', async () => {
+    const query = await getQuery(async () =>
+      Person.select((p) => [p.birthDate, p.name]),
+    );
+    const shapes = Person.shape.getPropertyShapes();
+    const birthDateShape = shapes.find((shape) => shape.label === 'birthDate');
+    const nameShape = shapes.find((shape) => shape.label === 'name');
+
+    expect(query?.select).toHaveLength(2);
+    expect(query?.select[0][0].property).toBe(birthDateShape);
+    expect(query?.select[1][0].property).toBe(nameShape);
+  });
+
+  test('selecting a boolean property builds a query object', async () => {
+    const query = await getQuery(async () =>
+      Person.select((p) => p.isRealPerson),
+    );
+    const propertyShape = Person.shape
+      .getPropertyShapes()
+      .find((shape) => shape.label === 'isRealPerson');
+
+    expect(query?.select).toHaveLength(1);
+    expect(query?.select[0][0].property).toBe(propertyShape);
+  });
+
+  test('selecting properties of a specific subject uses the subject', async () => {
+    const subject = {id: 'p1'};
+    const query = await getQuery(async () =>
+      Person.select(subject, (p) => p.name),
+    );
+
+    expect(query?.subject).toBe(subject);
+    expect(query?.singleResult).toBe(true);
+  });
+
+  test('selecting by id reference sets the subject', async () => {
+    const subject = {id: 'p2'};
+    const query = await getQuery(async () =>
+      Person.select(subject, (p) => p.name),
+    );
+
+    expect(query?.subject).toBe(subject);
+    expect(query?.singleResult).toBe(true);
+  });
+
+  test('selecting a missing subject still builds a query object', async () => {
+    const subject = {id: 'missing'};
+    const query = await getQuery(async () =>
+      Person.select(subject, (p) => p.name),
+    );
+
+    expect(query?.subject).toBe(subject);
+    expect(query?.singleResult).toBe(true);
+  });
+
+  test('selecting only nullable properties still records the paths', async () => {
+    const subject = {id: 'p3'};
+    const query = await getQuery(async () =>
+      Person.select(subject, (p) => [p.hobby, p.bestFriend]),
+    );
+    const shapes = Person.shape.getPropertyShapes();
+    const hobbyShape = shapes.find((shape) => shape.label === 'hobby');
+    const bestFriendShape = shapes.find(
+      (shape) => shape.label === 'bestFriend',
+    );
+
+    expect(query?.select).toHaveLength(2);
+    expect(query?.select[0][0].property).toBe(hobbyShape);
+    expect(query?.select[1][0].property).toBe(bestFriendShape);
+  });
+
+  test('selecting a nested property builds a multi-step path', async () => {
+    const query = await getQuery(async () =>
+      Person.select((p) => p.friends.name),
+    );
+    const shapes = Person.shape.getPropertyShapes();
+    const friendsShape = shapes.find((shape) => shape.label === 'friends');
+    const nameShape = shapes.find((shape) => shape.label === 'name');
+
+    expect(query?.select).toHaveLength(1);
+    expect(query?.select[0]).toHaveLength(2);
+    expect(query?.select[0][0].property).toBe(friendsShape);
+    expect(query?.select[0][1].property).toBe(nameShape);
+  });
+
+  test('selecting a nested set builds multiple steps', async () => {
+    const query = await getQuery(async () =>
+      Person.select((p) => p.friends.friends),
+    );
+    const shapes = Person.shape.getPropertyShapes();
+    const friendsShape = shapes.find((shape) => shape.label === 'friends');
+
+    expect(query?.select).toHaveLength(1);
+    expect(query?.select[0]).toHaveLength(2);
+    expect(query?.select[0][0].property).toBe(friendsShape);
+    expect(query?.select[0][1].property).toBe(friendsShape);
+  });
+
+  test('selecting multiple property paths includes nested paths', async () => {
+    const query = await getQuery(async () =>
+      Person.select((p) => [p.name, p.friends, p.bestFriend.name]),
+    );
+    const shapes = Person.shape.getPropertyShapes();
+    const nameShape = shapes.find((shape) => shape.label === 'name');
+    const friendsShape = shapes.find((shape) => shape.label === 'friends');
+    const bestFriendShape = shapes.find((shape) => shape.label === 'bestFriend');
+
+    expect(query?.select).toHaveLength(3);
+    expect(query?.select[0][0].property).toBe(nameShape);
+    expect(query?.select[1][0].property).toBe(friendsShape);
+    expect(query?.select[2][0].property).toBe(bestFriendShape);
+    expect(query?.select[2][1].property).toBe(nameShape);
+  });
+
+  test('selecting a property of a single shape builds a nested path', async () => {
+    const query = await getQuery(async () =>
+      Person.select((p) => p.bestFriend.name),
+    );
+    const shapes = Person.shape.getPropertyShapes();
+    const bestFriendShape = shapes.find((shape) => shape.label === 'bestFriend');
+    const nameShape = shapes.find((shape) => shape.label === 'name');
+
+    expect(query?.select).toHaveLength(1);
+    expect(query?.select[0]).toHaveLength(2);
+    expect(query?.select[0][0].property).toBe(bestFriendShape);
+    expect(query?.select[0][1].property).toBe(nameShape);
+  });
+
+  test('selecting 3-level deep nested paths builds full paths', async () => {
+    const query = await getQuery(async () =>
+      Person.select((p) => p.friends.friends.friends),
+    );
+    const shapes = Person.shape.getPropertyShapes();
+    const friendsShape = shapes.find((shape) => shape.label === 'friends');
+
+    expect(query?.select).toHaveLength(1);
+    expect(query?.select[0]).toHaveLength(3);
+    expect(query?.select[0][0].property).toBe(friendsShape);
+    expect(query?.select[0][1].property).toBe(friendsShape);
+    expect(query?.select[0][2].property).toBe(friendsShape);
+  });
+
+  describe('filtering (where clauses)', () => {
+    test('selecting a set with where() adds a where path', async () => {
+      const query = await getQuery(async () =>
+        Person.select((p) =>
+          (p.friends as any).where((f: any) => f.name.equals('Moa')),
+        ),
+      );
+      const shapes = Person.shape.getPropertyShapes();
+      const friendsShape = shapes.find((shape) => shape.label === 'friends');
+      const nameShape = shapes.find((shape) => shape.label === 'name');
+
+      const step = query?.select[0][0];
+      expect(step?.property).toBe(friendsShape);
+      expect(step?.where?.method).toBe('=');
+      expect(step?.where?.path[0].property).toBe(friendsShape);
+      expect(step?.where?.path[1].property).toBe(nameShape);
+      expect(step?.where?.args[0]).toBe('Moa');
+    });
+
+    test('where on literal property adds where to property step', async () => {
+      const query = await getQuery(async () =>
+        Person.select((p) =>
+          (p.hobby as any).where((h: any) => h.equals('Jogging')),
+        ),
+      );
+      const shapes = Person.shape.getPropertyShapes();
+      const hobbyShape = shapes.find((shape) => shape.label === 'hobby');
+
+      const step = query?.select[0][0];
+      expect(step?.property).toBe(hobbyShape);
+      expect(step?.where?.method).toBe('=');
+      expect(step?.where?.args[0]).toBe('Jogging');
+    });
+
+    test('outer where() sets where on the query object', async () => {
+      const query = await getQuery(async () =>
+        (Person.select() as any).where((p: any) => p.name.equals('Semmy')),
+      );
+      const shapes = Person.shape.getPropertyShapes();
+      const nameShape = shapes.find((shape) => shape.label === 'name');
+
+      expect(query?.select).toHaveLength(0);
+      const where = query?.where as any;
+      expect(where?.method).toBe('=');
+      expect(where?.path[0].property).toBe(nameShape);
+      expect(where?.args[0]).toBe('Semmy');
+    });
+
+    test('and/or chains generate combined where paths', async () => {
+      const query = await getQuery(async () =>
+        Person.select((p) =>
+          (p.friends as any).where((f: any) =>
+            f.name.equals('Moa').and(f.hobby.equals('Jogging')),
+          ),
+        ),
+      );
+      const shapes = Person.shape.getPropertyShapes();
+      const friendsShape = shapes.find((shape) => shape.label === 'friends');
+      const nameShape = shapes.find((shape) => shape.label === 'name');
+      const hobbyShape = shapes.find((shape) => shape.label === 'hobby');
+
+      const step = query?.select[0][0];
+      expect(step?.property).toBe(friendsShape);
+      expect(step?.where?.firstPath.path[0].property).toBe(friendsShape);
+      expect(step?.where?.firstPath.path[1].property).toBe(nameShape);
+      expect(step?.where?.andOr[0].and.path[0].property).toBe(friendsShape);
+      expect(step?.where?.andOr[0].and.path[1].property).toBe(hobbyShape);
+    });
+
+    test('some() produces a some where path', async () => {
+      const query = await getQuery(async () =>
+        (Person.select() as any).where((p: any) =>
+          (p.friends as any).some((f: any) => f.name.equals('Moa')),
+        ),
+      );
+      const shapes = Person.shape.getPropertyShapes();
+      const friendsShape = shapes.find((shape) => shape.label === 'friends');
+      const nameShape = shapes.find((shape) => shape.label === 'name');
+
+      const where = query?.where as any;
+      expect(where?.method).toBe('some');
+      expect(where?.path[0].property).toBe(friendsShape);
+      const nested = where?.args[0];
+      expect(nested.path[0].property).toBe(friendsShape);
+      expect(nested.path[1].property).toBe(nameShape);
+    });
+
+    test('every() produces an every where path', async () => {
+      const query = await getQuery(async () =>
+        (Person.select() as any).where((p: any) =>
+          (p.friends as any).every((f: any) => f.name.equals('Jinx')),
+        ),
+      );
+      const shapes = Person.shape.getPropertyShapes();
+      const friendsShape = shapes.find((shape) => shape.label === 'friends');
+      const nameShape = shapes.find((shape) => shape.label === 'name');
+
+      const where = query?.where as any;
+      expect(where?.method).toBe('every');
+      expect(where?.path[0].property).toBe(friendsShape);
+      const nested = where?.args[0];
+      expect(nested.path[0].property).toBe(friendsShape);
+      expect(nested.path[1].property).toBe(nameShape);
+    });
+  });
+
+  describe('aggregation & sub-select', () => {
+    test('count a shapeset adds a count step', async () => {
+      const query = await getQuery(async () =>
+        Person.select((p) => (p.friends as any).size()),
+      );
+      const shapes = Person.shape.getPropertyShapes();
+      const friendsShape = shapes.find((shape) => shape.label === 'friends');
+
+      const countStep = query?.select[0][0];
+      expect(countStep?.count[0].property).toBe(friendsShape);
+    });
+
+    test('count a nested property counts the full path', async () => {
+      const query = await getQuery(async () =>
+        Person.select((p) => ((p.friends as any).friends as any).size()),
+      );
+      const shapes = Person.shape.getPropertyShapes();
+      const friendsShape = shapes.find((shape) => shape.label === 'friends');
+
+      const countStep = query?.select[0][0];
+      expect(countStep?.count[0].property).toBe(friendsShape);
+      expect(countStep?.count[1].property).toBe(friendsShape);
+    });
+
+    test('sub select with custom object nests query paths', async () => {
+      const query = await getQuery(async () =>
+        Person.select((p) =>
+          (p.friends as any).select((f: any) => ({
+            numFriends: (f.friends as any).size(),
+          })),
+        ),
+      );
+      const shapes = Person.shape.getPropertyShapes();
+      const friendsShape = shapes.find((shape) => shape.label === 'friends');
+
+      const path = query?.select[0];
+      expect(path[0].property).toBe(friendsShape);
+      const nested = path[1];
+      expect(nested.numFriends[0].count[0].property).toBe(friendsShape);
+    });
+  });
+
+  describe('type casting & sorting', () => {
+    test('select shapeset as builds a query path with cast shape', async () => {
+      const query = await getQuery(async () =>
+        Person.select((p) => (p.pets as any).as(Dog).guardDogLevel),
+      );
+      const shapes = Person.shape.getPropertyShapes();
+      const petsShape = shapes.find((shape) => shape.label === 'pets');
+      const dogGuardShape = Dog.shape
+        .getPropertyShapes()
+        .find((shape) => shape.label === 'guardDogLevel');
+
+      expect(query?.select).toHaveLength(1);
+      expect(query?.select[0][0].property).toBe(petsShape);
+      expect(query?.select[0][1].property).toBe(dogGuardShape);
+    });
+
+    test('select shape as builds a query path with cast shape', async () => {
+      const query = await getQuery(async () =>
+        Person.select((p) => (p.firstPet as any).as(Dog).guardDogLevel),
+      );
+      const shapes = Person.shape.getPropertyShapes();
+      const firstPetShape = shapes.find((shape) => shape.label === 'firstPet');
+      const dogGuardShape = Dog.shape
+        .getPropertyShapes()
+        .find((shape) => shape.label === 'guardDogLevel');
+
+      expect(query?.select).toHaveLength(1);
+      expect(query?.select[0][0].property).toBe(firstPetShape);
+      expect(query?.select[0][1].property).toBe(dogGuardShape);
+    });
+
+    test('sortBy adds sort path and direction', async () => {
+      const query = await getQuery(async () =>
+        (Person.select((p) => p.name) as any).sortBy((p: any) => p.name),
+      );
+      const nameShape = Person.shape
+        .getPropertyShapes()
+        .find((shape) => shape.label === 'name');
+
+      expect(query?.sortBy?.direction).toBe('ASC');
+      expect(query?.sortBy?.paths[0][0].property).toBe(nameShape);
+    });
+
+    test('limit sets the limit on the query object', async () => {
+      const query = await getQuery(async () =>
+        (Person.select((p) => p.name) as any).limit(1),
+      );
+
+      expect(query?.limit).toBe(1);
+    });
+  });
+
+  describe('crud query objects', () => {
+    test('create builds a create query object', async () => {
+      const store = new QueryCaptureStore();
+      Person.queryParser = store;
+
+      await Person.create({name: 'New Person', hobby: 'Hiking'});
+
+      const query = store.getCreateQuery();
+      const shapes = Person.shape.getPropertyShapes();
+      const nameShape = shapes.find((shape) => shape.label === 'name');
+      const hobbyShape = shapes.find((shape) => shape.label === 'hobby');
+
+      expect(query?.type).toBe('create');
+      expect(query?.shape).toBe(Person.shape);
+      expect(query?.description.fields[0].prop).toBe(nameShape);
+      expect(query?.description.fields[0].val).toBe('New Person');
+      expect(query?.description.fields[1].prop).toBe(hobbyShape);
+      expect(query?.description.fields[1].val).toBe('Hiking');
+    });
+
+    test('update builds an update query object', async () => {
+      const store = new QueryCaptureStore();
+      Person.queryParser = store;
+
+      await Person.update('p1', {hobby: 'Gaming'});
+
+      const query = store.getUpdateQuery();
+      const hobbyShape = Person.shape
+        .getPropertyShapes()
+        .find((shape) => shape.label === 'hobby');
+
+      expect(query?.type).toBe('update');
+      expect(query?.id).toBe('p1');
+      expect(query?.shape).toBe(Person.shape);
+      expect(query?.updates.fields[0].prop).toBe(hobbyShape);
+      expect(query?.updates.fields[0].val).toBe('Gaming');
+    });
+
+    test('delete builds a delete query object', async () => {
+      const store = new QueryCaptureStore();
+      Person.queryParser = store;
+
+      await Person.delete(['p1', {id: 'p2'}]);
+
+      const query = store.getDeleteQuery();
+      expect(query?.type).toBe('delete');
+      expect(query?.shape).toBe(Person.shape);
+      expect(query?.ids).toEqual([{id: 'p1'}, {id: 'p2'}]);
+    });
   });
 });

--- a/rebrand/linked-js/src/tests/query-basic.test.ts
+++ b/rebrand/linked-js/src/tests/query-basic.test.ts
@@ -1,55 +1,24 @@
 import {describe, expect, test} from '@jest/globals';
-import {linkedShape, literalProperty, objectProperty, Shape} from '../package.js';
+import {literalProperty, objectProperty, Shape} from '../package.js';
 import {CreateQueryFactory} from '../queries/CreateQuery.js';
 import {DeleteQueryFactory} from '../queries/DeleteQuery.js';
 import {SelectQueryFactory} from '../queries/SelectQuery.js';
 import {UpdateQueryFactory} from '../queries/UpdateQuery.js';
+import {queryTestFixtures} from '../test-helpers/query-fixtures.js';
 
-const name = 'name';
-const bestFriend = 'bestFriend';
-const friends = 'friends';
-const pets = 'pets';
-const firstPet = 'firstPet';
-const hobby = 'hobby';
-const birthDate = 'birthDate';
-const isRealPerson = 'isRealPerson';
-const guardDogLevel = 'guardDogLevel';
-
-@linkedShape
-class Pet extends Shape {}
-
-@linkedShape
-class Dog extends Pet {
-  @literalProperty({path: guardDogLevel, maxCount: 1})
-  declare guardDogLevel: number;
-}
-
-@linkedShape
-class Person extends Shape {
-  @literalProperty({path: name, maxCount: 1})
-  declare name: string;
-
-  @objectProperty({path: bestFriend, maxCount: 1, shape: Person})
-  declare bestFriend: Person;
-
-  @objectProperty({path: friends, shape: Person})
-  declare friends: Person;
-
-  @objectProperty({path: pets, shape: Pet})
-  declare pets: Pet;
-
-  @objectProperty({path: firstPet, shape: Pet, maxCount: 1})
-  declare firstPet: Pet;
-
-  @literalProperty({path: hobby, maxCount: 1})
-  declare hobby: string;
-
-  @literalProperty({path: birthDate, maxCount: 1})
-  declare birthDate: Date;
-
-  @literalProperty({path: isRealPerson, maxCount: 1})
-  declare isRealPerson: boolean;
-}
+const {
+  Person,
+  Dog,
+  name,
+  bestFriend,
+  friends,
+  pets,
+  firstPet,
+  hobby,
+  birthDate,
+  isRealPerson,
+  guardDogLevel,
+} = queryTestFixtures;
 
 class QueryCaptureStore {
   lastQueryFactory?: SelectQueryFactory<Shape>;

--- a/rebrand/linked-js/src/tests/shapes-metadata.test.ts
+++ b/rebrand/linked-js/src/tests/shapes-metadata.test.ts
@@ -2,11 +2,22 @@ import {describe, expect, test} from '@jest/globals';
 import {linkedPackage} from '../utils/Package.js';
 import {linkedShape, literalProperty, objectProperty, Shape} from '../package.js';
 import {getNodeShapeUri} from '../shapes/shacl.js';
+import {
+  getMostSpecificSubShapes,
+  getShapeClassById,
+  getSubShapesClasses,
+  getSuperShapesClasses,
+  resetShapeClassRegistry,
+} from '../utils/ShapeClass.js';
 
 const name = 'name';
 const friend = 'friend';
 
 describe('shape metadata generation', () => {
+  afterEach(() => {
+    resetShapeClassRegistry();
+  });
+
   test('creates NodeShape and PropertyShape metadata with ids', () => {
     const pkg = linkedPackage('lincd-org');
 
@@ -39,5 +50,23 @@ describe('shape metadata generation', () => {
 
     const prop = Animal.shape.getPropertyShapes()[0].getResult();
     expect(prop.shape).toEqual({id: 'https://example.com/shape/Animal'});
+  });
+
+  test('shape registry tracks inheritance and reverse lookups', () => {
+    @linkedShape
+    class Base extends Shape {}
+
+    @linkedShape
+    class Child extends Base {}
+
+    const baseId = Base.shape.id;
+    const childId = Child.shape.id;
+
+    expect(getShapeClassById(baseId)).toBe(Base);
+    expect(getShapeClassById(childId)).toBe(Child);
+
+    expect(getSubShapesClasses(Base)).toContain(Child);
+    expect(getSuperShapesClasses(Child)).toContain(Base);
+    expect(getMostSpecificSubShapes(Base)).toContain(Child);
   });
 });

--- a/rebrand/linked-js/src/tests/shapes-metadata.test.ts
+++ b/rebrand/linked-js/src/tests/shapes-metadata.test.ts
@@ -1,0 +1,43 @@
+import {describe, expect, test} from '@jest/globals';
+import {linkedPackage} from '../utils/Package.js';
+import {linkedShape, literalProperty, objectProperty, Shape} from '../package.js';
+import {getNodeShapeUri} from '../shapes/shacl.js';
+
+const name = 'name';
+const friend = 'friend';
+
+describe('shape metadata generation', () => {
+  test('creates NodeShape and PropertyShape metadata with ids', () => {
+    const pkg = linkedPackage('lincd-org');
+
+    @pkg.linkedShape
+    class Person extends Shape {
+      @literalProperty({path: name, maxCount: 1})
+      declare name: string;
+
+      @objectProperty({path: friend, shape: Person})
+      declare friend: Person;
+    }
+
+    const nodeShape = Person.shape;
+    const expectedShapeId = getNodeShapeUri('lincd-org', 'Person');
+
+    expect(nodeShape.id).toBe(expectedShapeId);
+    expect(nodeShape.properties).toHaveLength(2);
+    expect(nodeShape.properties[0].id).toBe(`${expectedShapeId}/name`);
+    expect(nodeShape.properties[0].path).toEqual({id: name});
+    expect(nodeShape.properties[1].path).toEqual({id: friend});
+    expect(nodeShape.properties[1].shape).toEqual({id: expectedShapeId});
+  });
+
+  test('objectProperty accepts explicit shape ids', () => {
+    @linkedShape
+    class Animal extends Shape {
+      @objectProperty({path: friend, shape: 'https://example.com/shape/Animal'})
+      declare friend: Shape;
+    }
+
+    const prop = Animal.shape.getPropertyShapes()[0].getResult();
+    expect(prop.shape).toEqual({id: 'https://example.com/shape/Animal'});
+  });
+});

--- a/rebrand/linked-js/src/utils/LinkedStorage.ts
+++ b/rebrand/linked-js/src/utils/LinkedStorage.ts
@@ -1,0 +1,65 @@
+import type {IQueryStore} from '../interfaces/IQueryStore.js';
+import type {CreateQuery} from '../queries/CreateQuery.js';
+import type {DeleteQuery} from '../queries/DeleteQuery.js';
+import type {SelectQuery} from '../queries/SelectQuery.js';
+import type {UpdateQuery} from '../queries/UpdateQuery.js';
+import {QueryParser} from '../queries/QueryParser.js';
+import {Shape} from '../shapes/Shape.js';
+
+export class LinkedStorage {
+  private static defaultStore?: IQueryStore;
+  private static shapeToStore: Map<typeof Shape, IQueryStore> = new Map();
+  private static initialized = false;
+
+  static init() {
+    if (!this.initialized) {
+      Shape.queryParser = QueryParser;
+      this.initialized = true;
+    }
+  }
+
+  static setDefaultStore(store: IQueryStore) {
+    this.defaultStore = store;
+    this.init();
+  }
+
+  static getDefaultStore() {
+    return this.defaultStore;
+  }
+
+  static setStoreForShapes(store: IQueryStore, ...shapes: (typeof Shape)[]) {
+    shapes.forEach((shape) => this.shapeToStore.set(shape, store));
+    this.init();
+  }
+
+  static reset() {
+    this.defaultStore = undefined;
+    this.shapeToStore.clear();
+  }
+
+  static getStoreForShape(shape?: typeof Shape): IQueryStore {
+    if (shape && this.shapeToStore.has(shape)) {
+      return this.shapeToStore.get(shape);
+    }
+    if (this.defaultStore) {
+      return this.defaultStore;
+    }
+    throw new Error('No default store configured for LinkedStorage');
+  }
+
+  static selectQuery<ResultType>(query: SelectQuery, shape?: typeof Shape) {
+    return this.getStoreForShape(shape).selectQuery<ResultType>(query);
+  }
+
+  static createQuery<ResultType>(query: CreateQuery, shape?: typeof Shape) {
+    return this.getStoreForShape(shape).createQuery<ResultType>(query);
+  }
+
+  static updateQuery<ResultType>(query: UpdateQuery, shape?: typeof Shape) {
+    return this.getStoreForShape(shape).updateQuery<ResultType>(query);
+  }
+
+  static deleteQuery<ResultType>(query: DeleteQuery, shape?: typeof Shape) {
+    return this.getStoreForShape(shape).deleteQuery<ResultType>(query);
+  }
+}

--- a/rebrand/linked-js/src/utils/Package.ts
+++ b/rebrand/linked-js/src/utils/Package.ts
@@ -1,0 +1,83 @@
+import {Shape} from '../shapes/Shape.js';
+import {linkedShape as baseLinkedShape} from '../shapes/decorators.js';
+import {getNodeShapeUri} from '../shapes/shacl.js';
+
+type PackageExports = Record<string, unknown>;
+
+const packages = new Map<string, PackageExports>();
+
+const getPackageExports = (name: string): PackageExports => {
+  if (!packages.has(name)) {
+    packages.set(name, {});
+  }
+  return packages.get(name);
+};
+
+const registerExport = (exports: PackageExports, exported: any) => {
+  if (!exported?.name) {
+    return;
+  }
+  exports[exported.name] = exported;
+};
+
+export type LinkedPackageObject = {
+  linkedShape: {
+    <T extends typeof Shape>(constructor: T): void;
+    <T extends typeof Shape>(config?: Record<string, unknown>): (constructor: T) => void;
+  };
+  linkedUtil: (constructor: any) => any;
+  linkedOntology: (...args: unknown[]) => void;
+  registerPackageExport: (exportedObject: any) => void;
+  getPackageShape: (name: string) => typeof Shape;
+  packageExports: PackageExports;
+  packageName: string;
+};
+
+export const linkedPackage = (name: string): LinkedPackageObject => {
+  const packageExports = getPackageExports(name);
+
+  const linkedShape = ((config?: Record<string, unknown>) => {
+    if (typeof config === 'function') {
+      const target = config as unknown as typeof Shape;
+      (target as any).packageName = name;
+      baseLinkedShape(target);
+      if (target.shape && !target.shape.id) {
+        target.shape.id = getNodeShapeUri(name, target.name);
+      }
+      registerExport(packageExports, target);
+      return;
+    }
+    return (constructor: typeof Shape) => {
+      (constructor as any).packageName = name;
+      baseLinkedShape(constructor);
+      if (constructor.shape && !constructor.shape.id) {
+        constructor.shape.id = getNodeShapeUri(name, constructor.name);
+      }
+      registerExport(packageExports, constructor);
+    };
+  }) as LinkedPackageObject['linkedShape'];
+
+  const linkedUtil = (constructor: any) => {
+    registerExport(packageExports, constructor);
+    return constructor;
+  };
+
+  const linkedOntology = (_exports, _ns, _suggestedName, _loader, _source) => {
+    registerExport(packageExports, _exports);
+  };
+
+  const getPackageShape = (shapeName: string) => {
+    return packageExports[shapeName] as typeof Shape;
+  };
+
+  return {
+    linkedShape,
+    linkedUtil,
+    linkedOntology,
+    registerPackageExport: (exportedObject: any) =>
+      registerExport(packageExports, exportedObject),
+    getPackageShape,
+    packageExports,
+    packageName: name,
+  };
+};

--- a/rebrand/linked-js/src/utils/ShapeClass.ts
+++ b/rebrand/linked-js/src/utils/ShapeClass.ts
@@ -1,0 +1,34 @@
+import type {PropertyShape} from '../shapes/PropertyShape.js';
+import {Shape} from '../shapes/Shape.js';
+
+export const getPropertyShapeByLabel = (
+  shapeClass: typeof Shape,
+  label: string,
+): PropertyShape | undefined => {
+  let current: typeof Shape = shapeClass;
+
+  while (current) {
+    const shapeDef = current.shape;
+    const propertyShape = shapeDef
+      ?.getPropertyShapes()
+      .find((shape) => shape.label === label);
+    if (propertyShape) {
+      return propertyShape;
+    }
+
+    const next = Object.getPrototypeOf(current);
+    if (!next || next === Shape || !(next.prototype instanceof Shape)) {
+      if (next?.shape) {
+        const nextProp = next.shape
+          .getPropertyShapes()
+          .find((shape) => shape.label === label);
+        if (nextProp) {
+          return nextProp;
+        }
+      }
+      break;
+    }
+    current = next;
+  }
+  return undefined;
+};

--- a/rebrand/linked-js/src/utils/ShapeClass.ts
+++ b/rebrand/linked-js/src/utils/ShapeClass.ts
@@ -8,8 +8,7 @@ export const getPropertyShapeByLabel = (
   let current: typeof Shape = shapeClass;
 
   while (current) {
-    const shapeDef = current.shape;
-    const propertyShape = shapeDef
+    const propertyShape = current.shape
       ?.getPropertyShapes()
       .find((shape) => shape.label === label);
     if (propertyShape) {
@@ -31,4 +30,8 @@ export const getPropertyShapeByLabel = (
     current = next;
   }
   return undefined;
+};
+
+export const getShapeId = (shapeClass: typeof Shape) => {
+  return shapeClass.shape?.id;
 };

--- a/rebrand/linked-js/src/utils/ShapeClass.ts
+++ b/rebrand/linked-js/src/utils/ShapeClass.ts
@@ -1,6 +1,75 @@
 import type {PropertyShape} from '../shapes/PropertyShape.js';
 import {Shape} from '../shapes/Shape.js';
 
+const shapeClassById = new Map<string, typeof Shape>();
+const idByShapeClass = new Map<typeof Shape, string>();
+
+export const registerShapeClass = (shapeClass: typeof Shape) => {
+  const id = shapeClass.shape?.id;
+  if (!id) {
+    return;
+  }
+  const previousId = idByShapeClass.get(shapeClass);
+  if (previousId && previousId !== id) {
+    shapeClassById.delete(previousId);
+  }
+  idByShapeClass.set(shapeClass, id);
+  shapeClassById.set(id, shapeClass);
+};
+
+export const getShapeClassById = (id: string): typeof Shape | undefined => {
+  return shapeClassById.get(id);
+};
+
+export const getRegisteredShapeClasses = (): (typeof Shape)[] => {
+  return Array.from(idByShapeClass.keys());
+};
+
+export const resetShapeClassRegistry = () => {
+  shapeClassById.clear();
+  idByShapeClass.clear();
+};
+
+export const hasSuperClass = (child: typeof Shape, parent: typeof Shape) => {
+  return child.prototype instanceof parent;
+};
+
+export const hasSubClass = (parent: typeof Shape, child: typeof Shape) => {
+  return child.prototype instanceof parent;
+};
+
+export const getSubShapesClasses = (
+  shape: typeof Shape | (typeof Shape)[],
+): (typeof Shape)[] => {
+  const shapes = Array.isArray(shape) ? shape : [shape];
+  return getRegisteredShapeClasses()
+    .filter((candidate) => shapes.some((base) => hasSubClass(base, candidate)))
+    .sort((a, b) => (hasSubClass(a, b) ? 1 : -1));
+};
+
+export const getSuperShapesClasses = (
+  shape: typeof Shape | (typeof Shape)[],
+): (typeof Shape)[] => {
+  const shapes = Array.isArray(shape) ? shape : [shape];
+  return getRegisteredShapeClasses()
+    .filter((candidate) => shapes.some((base) => hasSuperClass(base, candidate)))
+    .sort((a, b) => (hasSubClass(a, b) ? 1 : -1));
+};
+
+const filterShapesToMostSpecific = (shapeClasses: (typeof Shape)[]) => {
+  return shapeClasses.filter((shapeClass) => {
+    return !shapeClasses.some(
+      (other) => other !== shapeClass && hasSuperClass(other, shapeClass),
+    );
+  });
+};
+
+export const getMostSpecificSubShapes = (
+  shape: typeof Shape | (typeof Shape)[],
+): (typeof Shape)[] => {
+  return filterShapesToMostSpecific(getSubShapesClasses(shape));
+};
+
 export const getPropertyShapeByLabel = (
   shapeClass: typeof Shape,
   label: string,

--- a/rebrand/linked-js/tsconfig-cjs.json
+++ b/rebrand/linked-js/tsconfig-cjs.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "es6",
+    "outDir": "lib/cjs"
+  }
+}

--- a/rebrand/linked-js/tsconfig-esm.json
+++ b/rebrand/linked-js/tsconfig-esm.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "esnext",
+    "target": "es6",
+    "outDir": "lib/esm",
+    "moduleResolution": "node"
+  }
+}

--- a/rebrand/linked-js/tsconfig.json
+++ b/rebrand/linked-js/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "sourceMap": true,
+    "declaration": true,
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true,
+    "downlevelIteration": true,
+    "resolveJsonModule": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "pretty": true,
+    "types": ["node", "jest"],
+    "baseUrl": "./",
+    "paths": {
+      "*": ["node_modules/@types/*", "../../node_modules/@types/*", "*"]
+    }
+  },
+  "include": [
+    "./src/**/*.ts",
+    "../node_modules/ts-jest/globals.d.ts"
+  ]
+}

--- a/rebrand/linked-mem-store/jest.config.cjs
+++ b/rebrand/linked-mem-store/jest.config.cjs
@@ -1,0 +1,6 @@
+/** @type {import('ts-jest/dist/types').InitialOptionsTsJest} */
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'jsdom',
+  rootDir: 'lib/cjs/tests',
+};

--- a/rebrand/linked-mem-store/jest.config.cjs
+++ b/rebrand/linked-mem-store/jest.config.cjs
@@ -2,5 +2,10 @@
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'jsdom',
-  rootDir: 'lib/cjs/tests',
+  rootDir: 'lib/cjs/linked-mem-store/src/tests',
+  moduleNameMapper: {
+    '^linked-js/(.*)\\.js$': '<rootDir>/../../../../../../linked-js/lib/cjs/$1',
+    '^linked-js/(.*)$': '<rootDir>/../../../../../../linked-js/lib/cjs/$1',
+    '^linked-js$': '<rootDir>/../../../../../../linked-js/lib/cjs/index.js',
+  },
 };

--- a/rebrand/linked-mem-store/package.json
+++ b/rebrand/linked-mem-store/package.json
@@ -28,9 +28,10 @@
     "build": "node ../../node_modules/.bin/rimraf ./lib && node ../../node_modules/.bin/tsc -p tsconfig-cjs.json && node ../../node_modules/.bin/tsc -p tsconfig-esm.json && node ./scripts/dual-package.js",
     "compile": "echo '💫 Compiling CJS' && node ../../node_modules/.bin/tsc -p tsconfig-cjs.json && echo '💫 Compiling ESM' && node ../../node_modules/.bin/tsc -p tsconfig-esm.json",
     "dual-package": "node ./scripts/dual-package.js",
-    "test": "node ../../node_modules/.bin/rimraf ./lib && node ../../node_modules/.bin/tsc -p tsconfig-cjs.json && node ../../node_modules/.bin/tsc -p tsconfig-esm.json && node ./scripts/dual-package.js && node ../../node_modules/.bin/jest --config jest.config.cjs"
+    "test": "cd ../linked-js && node ../../node_modules/.bin/rimraf ./lib && node ../../node_modules/.bin/tsc -p tsconfig-cjs.json && node ../../node_modules/.bin/tsc -p tsconfig-esm.json && node ./scripts/dual-package.js && cd ../linked-mem-store && node ../../node_modules/.bin/rimraf ./lib && node ../../node_modules/.bin/tsc -p tsconfig-cjs.json && node ../../node_modules/.bin/tsc -p tsconfig-esm.json && node ./scripts/dual-package.js && node ../../node_modules/.bin/jest --config jest.config.cjs"
   },
   "dependencies": {
+    "linked-js": "0.0.0",
     "eventemitter3": "5.0.1",
     "rdflib": "^2.2.33"
   },

--- a/rebrand/linked-mem-store/package.json
+++ b/rebrand/linked-mem-store/package.json
@@ -25,10 +25,10 @@
     }
   },
   "scripts": {
-    "build": "node ../../node_modules/.bin/rimraf ./lib && node ../../node_modules/.bin/tsc -p tsconfig-cjs.json && node ../../node_modules/.bin/tsc -p tsconfig-esm.json && node ./scripts/dual-package.js",
+    "build": "../../node_modules/.bin/rimraf ./lib && node ../../node_modules/.bin/tsc -p tsconfig-cjs.json && node ../../node_modules/.bin/tsc -p tsconfig-esm.json && node ./scripts/dual-package.js",
     "compile": "echo '💫 Compiling CJS' && node ../../node_modules/.bin/tsc -p tsconfig-cjs.json && echo '💫 Compiling ESM' && node ../../node_modules/.bin/tsc -p tsconfig-esm.json",
     "dual-package": "node ./scripts/dual-package.js",
-    "test": "cd ../linked-js && node ../../node_modules/.bin/rimraf ./lib && node ../../node_modules/.bin/tsc -p tsconfig-cjs.json && node ../../node_modules/.bin/tsc -p tsconfig-esm.json && node ./scripts/dual-package.js && cd ../linked-mem-store && node ../../node_modules/.bin/rimraf ./lib && node ../../node_modules/.bin/tsc -p tsconfig-cjs.json && node ../../node_modules/.bin/tsc -p tsconfig-esm.json && node ./scripts/dual-package.js && node ../../node_modules/.bin/jest --config jest.config.cjs"
+    "test": "cd ../linked-js && ../../node_modules/.bin/rimraf ./lib && node ../../node_modules/.bin/tsc -p tsconfig-cjs.json && node ../../node_modules/.bin/tsc -p tsconfig-esm.json && node ./scripts/dual-package.js && cd ../linked-mem-store && ../../node_modules/.bin/rimraf ./lib && node ../../node_modules/.bin/tsc -p tsconfig-cjs.json && node ../../node_modules/.bin/tsc -p tsconfig-esm.json && node ./scripts/dual-package.js && node ../../node_modules/.bin/jest --config jest.config.cjs"
   },
   "dependencies": {
     "linked-js": "0.0.0",

--- a/rebrand/linked-mem-store/package.json
+++ b/rebrand/linked-mem-store/package.json
@@ -1,0 +1,46 @@
+{
+  "name": "linked-mem-store",
+  "version": "0.0.0",
+  "license": "MPL-2.0",
+  "description": "Linked in-memory RDF models and collections",
+  "main": "lib/cjs/index.js",
+  "module": "lib/esm/index.js",
+  "exports": {
+    ".": {
+      "types": "./lib/esm/index.d.ts",
+      "import": "./lib/esm/index.js",
+      "require": "./lib/cjs/index.js"
+    },
+    "./*": {
+      "types": "./lib/esm/*.d.ts",
+      "import": "./lib/esm/*.js",
+      "require": "./lib/cjs/*.js"
+    }
+  },
+  "typesVersions": {
+    "*": {
+      "*": [
+        "lib/esm/*"
+      ]
+    }
+  },
+  "scripts": {
+    "build": "node ../../node_modules/.bin/rimraf ./lib && node ../../node_modules/.bin/tsc -p tsconfig-cjs.json && node ../../node_modules/.bin/tsc -p tsconfig-esm.json && node ./scripts/dual-package.js",
+    "compile": "echo '💫 Compiling CJS' && node ../../node_modules/.bin/tsc -p tsconfig-cjs.json && echo '💫 Compiling ESM' && node ../../node_modules/.bin/tsc -p tsconfig-esm.json",
+    "dual-package": "node ./scripts/dual-package.js",
+    "test": "node ../../node_modules/.bin/rimraf ./lib && node ../../node_modules/.bin/tsc -p tsconfig-cjs.json && node ../../node_modules/.bin/tsc -p tsconfig-esm.json && node ./scripts/dual-package.js && node ../../node_modules/.bin/jest --config jest.config.cjs"
+  },
+  "dependencies": {
+    "eventemitter3": "5.0.1",
+    "rdflib": "^2.2.33"
+  },
+  "devDependencies": {
+    "@jest/globals": "^29.7.0",
+    "@types/jest": "^29.5.12",
+    "@types/node": "^20.12.7",
+    "jest": "^29.7.0",
+    "rimraf": "^5.0.7",
+    "ts-jest": "^29.1.2",
+    "typescript": "^5.7.3"
+  }
+}

--- a/rebrand/linked-mem-store/scripts/dual-package.js
+++ b/rebrand/linked-mem-store/scripts/dual-package.js
@@ -1,0 +1,25 @@
+const fs = require('fs');
+const path = require('path');
+
+const root = path.resolve(__dirname,'..');
+const libDir = path.join(root,'lib');
+const cjsDir = path.join(libDir,'cjs');
+const esmDir = path.join(libDir,'esm');
+
+const ensureDir = (dir) => {
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir,{recursive: true});
+  }
+};
+
+const writePackageJson = (dir,type) => {
+  ensureDir(dir);
+  const pkgPath = path.join(dir,'package.json');
+  const data = {
+    type,
+  };
+  fs.writeFileSync(pkgPath,JSON.stringify(data,null,2));
+};
+
+writePackageJson(cjsDir,'commonjs');
+writePackageJson(esmDir,'module');

--- a/rebrand/linked-mem-store/src/collections/CoreMap.ts
+++ b/rebrand/linked-mem-store/src/collections/CoreMap.ts
@@ -1,0 +1,127 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+import {ICoreIterable} from '../interfaces/ICoreIterable.js';
+
+export class CoreMap<K, V> extends Map<K, V> implements ICoreIterable<V> {
+  createNew(...args): this {
+    return new (<any>this.constructor)(...args) as this;
+  }
+
+  /**
+   * Determines whether all the members of an array satisfy the specified test.
+   * @param callbackfn A function that accepts up to three arguments. The every method calls the callbackfn function for each element in array1 until the callbackfn returns false, or until the end of the array.
+   * @param thisArg An object to which the this keyword can refer in the callbackfn function. If thisArg is omitted, undefined is used as the this value.
+   */
+  every(
+    callbackfn: (value: V, key: K, map: CoreMap<K, V>) => boolean,
+    thisArg?: any,
+  ): boolean {
+    for (let [key, value] of this) {
+      if (!callbackfn.apply(thisArg, [value, key, this])) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /**
+   * Determines whether the specified callback function returns true for any element of an array.
+   * @param callbackfn A function that accepts up to three arguments. The some method calls the callbackfn function for each element in array1 until the callbackfn returns true, or until the end of the array.
+   * @param thisArg An object to which the this keyword can refer in the callbackfn function. If thisArg is omitted, undefined is used as the this value.
+   */
+  some(
+    callbackfn: (value: V, key: K, map: CoreMap<K, V>) => boolean,
+    thisArg?: any,
+  ): boolean {
+    for (let [key, value] of this) {
+      if (callbackfn.apply(thisArg, [value, key, this])) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Calls a defined callback function on each element of an array, and returns an array that contains the results.
+   * @param callbackfn A function that accepts up to three arguments. The map method calls the callbackfn function one time for each element in the array.
+   * @param thisArg An object to which the this keyword can refer in the callbackfn function. If thisArg is omitted, undefined is used as the this value.
+   */
+  map<U>(
+    callbackfn: (value: V, key: K, map: Map<K, V>) => U,
+    thisArg?: any,
+  ): this {
+    //create the result map, whos values will be 'mapped' into new values from the current values of this map
+    //var mappedMap = new (<any> this.constructor)() as CoreMap<K,U>;
+    var mappedMap = new (<any>this.constructor)(); // as CoreMap<K,U>;
+    for (let [key, value] of this) {
+      //do the mapping
+      mappedMap.set(key, callbackfn.apply(thisArg, [value, key, this]));
+    }
+    return mappedMap;
+  }
+
+  /**
+   * Returns the elements of an array that meet the condition specified in a callback function.
+   * @param callbackfn A function that accepts up to three arguments. The filter method calls the callbackfn function one time for each element in the array.
+   * @param thisArg An object to which the this keyword can refer in the callbackfn function. If thisArg is omitted, undefined is used as the this value.
+   */
+  filter(
+    callbackfn: (value: V, key: K, map: Map<K, V>) => any,
+    thisArg?: any,
+  ): this {
+    //create the result map, whos values will be 'mapped' into new values from the current values of this map
+    var filteredMap = new (<any>this.constructor)(); //this.createNew();//new Map<K,V>();
+    for (let [key, value] of this) {
+      //do the mapping
+      if (callbackfn.apply(thisArg, [value, key, this])) {
+        filteredMap.set(key, value);
+      }
+    }
+    return filteredMap;
+  }
+
+  first(): V | null {
+    return this.values().next().value;
+  }
+
+  /**
+   * Returns the value of the first element in the Set where predicate is true, and undefined
+   * otherwise.
+   */
+  find(
+    predicate: (value: V, index: K, obj: CoreMap<K, V>) => boolean,
+    thisArg?: any,
+  ): V | undefined {
+    for (let [key, value] of this) {
+      if (predicate.apply(thisArg, [value, key, this])) {
+        return value;
+      }
+    }
+    return undefined;
+  }
+
+  merge(...maps: CoreMap<K, V>[]) {
+    var res = this.createNew(this);
+    for (var map of maps) {
+      map.forEach((value, index) => {
+        res.set(index, value);
+      });
+    }
+    return res;
+  }
+
+  toString() {
+    let res = 'Map:\n';
+    for (let [key, value] of this) {
+      res += '\t[' + key.toString() + '] => ' + value.toString() + '\n';
+    }
+    return res;
+  }
+
+  print() {
+    console.log(this.toString());
+  }
+}

--- a/rebrand/linked-mem-store/src/collections/CoreSet.ts
+++ b/rebrand/linked-mem-store/src/collections/CoreSet.ts
@@ -1,0 +1,171 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+import {ICoreIterable} from '../interfaces/ICoreIterable.js';
+
+export class CoreSet<R> extends Set<R> implements ICoreIterable<R> {
+  createNew(...args): this {
+    return new (<any>this.constructor)(...args) as this;
+  }
+
+  filter(fn: (value: R, index: any, thisInstance: any) => any): this {
+    var res: this = this.createNew();
+    for (var item of this) {
+      if (fn(item, item, this)) {
+        res.add(item);
+      }
+    }
+    return res;
+  }
+
+  reduce<U>(
+    fn: (
+      previousValue: U,
+      currentValue: R,
+      currentIndex: number,
+      thisInstance: any,
+    ) => U,
+    initialValue: U,
+  ): U {
+    let i = 0;
+    let res = initialValue;
+    for (let item of this) {
+      res = fn(res, item, i++, this);
+    }
+    return res;
+  }
+
+  /**
+   * Returns the value of the first element in the Set where predicate is true, and undefined
+   * otherwise.
+   */
+  find(
+    predicate: (value: R, index: R, obj: CoreSet<R>) => boolean,
+    thisArg?: any,
+  ): R | undefined {
+    for (let item of this) {
+      if (predicate.apply(thisArg, [item, item, this])) {
+        return item;
+      }
+    }
+    return undefined;
+  }
+
+  first(): R | undefined {
+    return this.values().next().value;
+  }
+
+  /**
+   * Returns the last element added to the set
+   */
+  last(): R {
+    //unfortunately there is no efficient way to do this. Either we convert the set to an array or we loop over all values to discover the last
+    let item;
+    for (item of this);
+    return item;
+  }
+
+  getFirst(n: number) {
+    return this.createNew([...this].slice(0, n));
+  }
+
+  slice(start?: number, end?: number) {
+    return this.createNew([...this].slice(start, end));
+  }
+
+  sort(compareFn?: (a: R, b: R) => number, thisArg?): this {
+    //convert this set to an array, sort it with provided parameters, create a new set of the same type and provide the sorted array as content
+    var sortedArray = thisArg
+      ? [...this].sort.apply(thisArg, [compareFn])
+      : [...this].sort(compareFn);
+    return this.createNew(sortedArray);
+  }
+
+  /**
+   * Determines whether all the members of an array satisfy the specified test.
+   * @param callbackfn A function that accepts up to three arguments. The every method calls the callbackfn function for each element in array1 until the callbackfn returns false, or until the end of the array.
+   * @param thisArg An object to which the this keyword can refer in the callbackfn function. If thisArg is omitted, undefined is used as the this value.
+   */
+  every(
+    callbackfn: (item: R, set: CoreSet<R>) => boolean,
+    thisArg?: any,
+  ): boolean {
+    for (let item of this) {
+      if (!callbackfn.apply(thisArg, [item, this])) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /**
+   * Determines whether the specified callback function returns true for any element of an array.
+   * @param callbackfn A function that accepts up to three arguments. The some method calls the callbackfn function for each element in array1 until the callbackfn returns true, or until the end of the array.
+   * @param thisArg An object to which the this keyword can refer in the callbackfn function. If thisArg is omitted, undefined is used as the this value.
+   */
+  some(
+    callbackfn: (item: R, set: CoreSet<R>) => boolean,
+    thisArg?: any,
+  ): boolean {
+    for (let item of this) {
+      if (callbackfn.apply(thisArg, [item, this])) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Calls a defined callback function on each element of the set, and returns an ARRAY that contains the results.
+   * Note that this method returns an array so that sets can be more easily used with for example JSX
+   * @param callbackfn A function that accepts up to three arguments. The map method calls the callbackfn function one time for each element in the array.
+   * @param thisArg An object to which the this keyword can refer in the callbackfn function. If thisArg is omitted, undefined is used as the this value.
+   */
+  map<U>(callbackfn: (item: R, set: CoreSet<R>) => U, thisArg?: any): U[] {
+    //NOTE: we changed this method so that it returns an array because it
+    // causes trouble in ES5 when we create a new CoreSet and try to add the mapped results which may not have a unique toString() implementation (like in React)
+
+    //create the result map, whos values will be 'mapped' into new values from the current values of this map
+    var mapped: U[] = [];
+    for (let item of this) {
+      //do the mapping
+      mapped.push(callbackfn.apply(thisArg, [item, this]));
+    }
+    return mapped;
+  }
+
+  concat(...sets: ICoreIterable<R>[]): this {
+    var res = this.createNew(this);
+    for (var set of sets) {
+      set.forEach(res.add.bind(res));
+    }
+    return res;
+  }
+
+  clone(): this {
+    return this.createNew(this);
+  }
+
+  reverse(): this {
+    return this.createNew([...this].reverse());
+  }
+
+  print() {
+    console.log(this.toString());
+  }
+
+  /**
+   * Similar to concat, but adds all items to THIS set instead of creating a new one
+   * @param sets
+   */
+  addFrom(...sets: ICoreIterable<R>[]): this {
+    for (var set of sets) {
+      if (set) {
+        set.forEach(this.add.bind(this));
+      }
+    }
+    return this;
+  }
+}

--- a/rebrand/linked-mem-store/src/collections/NodeMap.ts
+++ b/rebrand/linked-mem-store/src/collections/NodeMap.ts
@@ -1,0 +1,281 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+import {CoreMap} from './CoreMap.js';
+import {IGraphObjectSet} from '../interfaces/IGraphObjectSet.js';
+import {NamedNode,Node} from '../models.js';
+import {QuadSet} from './QuadSet.js';
+import {QuadArray} from './QuadArray.js';
+import {NodeSet} from './NodeSet.js';
+import {ICoreIterable} from '../interfaces/ICoreIterable.js';
+
+export class NodeMap<R extends Node>
+  extends CoreMap<string, R>
+  implements IGraphObjectSet<R>
+{
+  constructor(iterable?: Iterable<[string, R]>) {
+    super(iterable);
+  }
+
+  getQuads(property: NamedNode): QuadSet {
+    var res = new QuadSet();
+    for (var [key, node] of this) {
+      for (var quad of node.getQuads(property)) {
+        res.add(quad);
+      }
+    }
+    return res;
+  }
+
+  getInverseQuads(property: NamedNode): QuadSet {
+    var res = new QuadSet();
+    for (var [key, node] of this) {
+      for (var quad of node.getInverseQuads(property)) {
+        res.add(quad);
+      }
+    }
+    return res;
+  }
+
+  getAll(property: NamedNode): NodeSet {
+    var res = new NodeSet();
+    for (var [key, node] of this) {
+      res = res.concat(node.getAll(property));
+    }
+    return res;
+  }
+
+  getAllInverse(property: NamedNode): NodeSet<NamedNode> {
+    var res = new NodeSet<NamedNode>();
+    for (var [key, node] of this) {
+      res = res.concat(node.getAllInverse(property));
+    }
+    return res;
+  }
+
+  getMultipleInverse(properties: ICoreIterable<NamedNode>): NodeSet {
+    var res = new NodeSet();
+    for (var [key, node] of this) {
+      for (var property of properties) {
+        res = res.concat(node.getAllInverse(property));
+      }
+    }
+    return res;
+  }
+
+  getMultiple(properties: ICoreIterable<NamedNode>): NodeSet {
+    var res = new NodeSet();
+    for (var [key, node] of this) {
+      for (var property of properties) {
+        res = res.concat(node.getAll(property));
+      }
+    }
+    return res;
+  }
+
+  getDeep(property: NamedNode, maxDepth: number = Infinity): NodeSet {
+    var result = new NodeSet();
+    var stack: NodeSet = new NodeSet(this.values());
+    while (stack.size > 0 && maxDepth > 0) {
+      var nextLevelStack = new NodeSet();
+      for (let node of stack) {
+        for (var value of node.getAll(property)) {
+          if (!result.has(value)) {
+            result.add(value);
+            nextLevelStack.add(value);
+          }
+        }
+      }
+      stack = nextLevelStack;
+      maxDepth--;
+    }
+    return result;
+  }
+
+  getOneFromPath(...properties: NamedNode[]): Node | undefined {
+    //NOTE: same implementation as in NamedNode
+
+    //we just need one, so we do a depth-first algorithm which will be more performant, so:
+    //take first property
+    var property = properties.shift();
+
+    //if more properties left
+    if (properties.length > 0) {
+      var res;
+      //check if any of the values of that property for this node
+      //has a path to the rest of the properties, and if so return the found value
+      for (var value of this.getAll(property)) {
+        if ((res = value.getOneFromPath(...properties))) {
+          return res;
+        }
+      }
+    } else {
+      //return the first value possible
+      return this.getOne(property);
+    }
+  }
+
+  getAllFromPath(...properties: NamedNode[]): NodeSet {
+    //we just need all paths, so we can do a breadth first implementation
+    //take first property
+    var property = properties.shift();
+
+    if (properties.length > 0) {
+      //and ask the whole set of values to return all values of the rest of the path
+      return this.getAll(property).getAllFromPath(...properties);
+    } else {
+      return this.getAll(property);
+    }
+  }
+
+  getProperties(includeFromIncomingArcs: boolean = false): NodeSet<NamedNode> {
+    var res = new NodeSet<NamedNode>();
+    for (var [key, node] of this) {
+      res = res.concat(node.getProperties(includeFromIncomingArcs));
+    }
+    return res;
+  }
+
+  getInverseProperties(): NodeSet<NamedNode> {
+    var res = new NodeSet<NamedNode>();
+    for (var [key, node] of this) {
+      res = res.concat(node.getInverseProperties());
+    }
+    return res;
+  }
+
+  getOne(property: NamedNode): Node | any {
+    for (var [key, node] of this) {
+      if (node.hasProperty(property)) {
+        return node.getOne(property);
+      }
+    }
+  }
+
+  getOneInverse(property: NamedNode): NamedNode | any {
+    for (var [key, node] of this) {
+      if (node.hasInverseProperty(property)) {
+        return node.getOneInverse(property);
+      }
+    }
+  }
+
+  getAllQuads(
+    includeAsObject: boolean = false,
+    includeImplicit: boolean = false,
+  ): QuadArray {
+    var res = new QuadArray();
+    for (var [key, node] of this) {
+      for (var item of node.getAllQuads(includeAsObject, includeImplicit)) {
+        if (res.indexOf(item) === -1) {
+          res.push(item);
+        }
+      }
+    }
+    return res;
+  }
+
+  getAllInverseQuads(includeImplicit?: boolean): QuadArray {
+    var res = new QuadArray();
+    for (var [key, node] of this) {
+      for (var item of node.getAllInverseQuads(includeImplicit)) {
+        if (res.indexOf(item) === -1) {
+          res.push(item);
+        }
+      }
+    }
+    return res;
+  }
+
+  where(property: NamedNode, value: Node): this {
+    //TODO: test performance with
+    //return this.filter(r => r.has(property,value));
+    var res = this.createNew();
+    for (var [key, node] of this) {
+      if (node.has(property, value)) {
+        //as any apparently needed, strange that NamedNode is not seen as matching to R?
+        res.set(key, node);
+      }
+    }
+    return res;
+  }
+
+  getWhere(property: NamedNode, value: Node): Node | undefined {
+    for (var [key, node] of this) {
+      if (node.has(property, value)) {
+        return node;
+      }
+    }
+    return undefined;
+  }
+
+  setEach(property: NamedNode, value: Node): boolean {
+    let res = false;
+    for (var [key, node] of this) {
+      res = node.set(property, value) && res;
+    }
+    return res;
+  }
+
+  msetEach(property: NamedNode, values: ICoreIterable<Node>): boolean {
+    let res = false;
+    for (var [key, node] of this) {
+      res = node.mset(property, values) && res;
+    }
+    return res;
+  }
+
+  updateEach(property: NamedNode, value: Node): boolean {
+    let res = false;
+    for (var [key, node] of this) {
+      res = node.overwrite(property, value) && res;
+    }
+    return res;
+  }
+
+  mupdateEach(property: NamedNode, values: ICoreIterable<Node>): boolean {
+    let res = false;
+    for (var [key, node] of this) {
+      res = node.moverwrite(property, values) && res;
+    }
+    return res;
+  }
+
+  unsetEach(property: NamedNode, value: Node): boolean {
+    let res = false;
+    for (var [key, node] of this) {
+      res = node.unset(property, value) && res;
+    }
+    return res;
+  }
+
+  unsetAllEach(property: NamedNode): boolean {
+    let res = false;
+    for (var [key, node] of this) {
+      res = node.unsetAll(property) && res;
+    }
+    return res;
+  }
+
+  promiseLoaded(loadInverseProperties: boolean = false): Promise<boolean> {
+    return Promise.all(
+      [...this.values()].map((node) =>
+        node.promiseLoaded(loadInverseProperties),
+      ),
+    )
+      .then((res) => {
+        return res.every((result) => result === true);
+      })
+      .catch(() => {
+        return false;
+      });
+  }
+
+  isLoaded(includingInverseProperties: boolean = false): boolean {
+    return [...this.values()].every((value) =>
+      value.isLoaded(includingInverseProperties),
+    );
+  }
+}

--- a/rebrand/linked-mem-store/src/collections/NodeSet.ts
+++ b/rebrand/linked-mem-store/src/collections/NodeSet.ts
@@ -1,0 +1,341 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+import {CoreSet} from './CoreSet.js';
+import {Literal,NamedNode,Node} from '../models.js';
+import {IGraphObjectSet} from '../interfaces/IGraphObjectSet.js';
+import {QuadSet} from './QuadSet.js';
+import {QuadArray} from './QuadArray.js';
+import {ICoreIterable} from '../interfaces/ICoreIterable.js';
+import {Debug} from '../utils/Debug.js';
+import {URI} from '../utils/URI.js';
+
+export class NodeSet<R extends Node = Node>
+  extends CoreSet<R>
+  implements IGraphObjectSet<Node>
+{
+  constructor(iterable?: Iterable<R>) {
+    super(iterable);
+  }
+
+  static fromValues<T extends Node = Node>(strings: string[]): NodeSet<T> {
+    return new NodeSet<T>(
+      strings.map(
+        (s) =>
+          (URI.isURI(s)
+            ? NamedNode.getOrCreate(s)
+            : new Literal(s)) as any as T,
+      ),
+    );
+  }
+
+  //we cannot use NamedNodeSet here because of requirement loops
+  getProperties(includeFromIncomingArcs: boolean = false): NodeSet<NamedNode> {
+    var res = new NodeSet<NamedNode>();
+    for (var node of this) {
+      res = res.concat(node.getProperties(includeFromIncomingArcs));
+    }
+    return res;
+  }
+
+  getInverseProperties(): NodeSet<NamedNode> {
+    var res = new NodeSet<NamedNode>();
+    for (var node of this) {
+      res = res.concat(node.getInverseProperties());
+    }
+    return res;
+  }
+
+  getOne(property: NamedNode): Node | undefined {
+    for (var node of this) {
+      if (node.hasProperty(property)) {
+        return node.getOne(property);
+      }
+    }
+    return undefined;
+  }
+
+  /**
+   * Returns a NodeSet containing the merged results of node.get(property) for each node in this set
+   * @param property
+   * @returns {NodeSet}
+   */
+  getAll(property: NamedNode): NodeSet {
+    var res = new NodeSet();
+    for (var node of this) {
+      res = res.concat(node.getAll(property));
+    }
+    return res;
+  }
+
+  getValues(property: NamedNode): string[] {
+    var res = [];
+    for (var node of this) {
+      res.push(node.getValue(property));
+    }
+    return res;
+  }
+
+  /**
+   * Returns an array of the URI's or literal values (for Literals) of the nodes in this set
+   */
+  getNodeValues(): string[] {
+    var res = [];
+    for (var node of this) {
+      res.push(node.value);
+    }
+    return res;
+  }
+
+  getOneFromPath(...properties: NamedNode[]): Node | undefined {
+    //NOTE: same implementation as in NamedNode
+
+    //we just need one, so we do a depth-first algorithm which will be more performant, so:
+    //take first property
+    var property = properties.shift();
+
+    //if more properties left
+    if (properties.length > 0) {
+      var res;
+      //check if any of the values of that property for this node
+      //has a path to the rest of the properties, and if so return the found value
+      for (var value of this.getAll(property)) {
+        if ((res = value.getOneFromPath(...properties))) {
+          return res;
+        }
+      }
+    } else {
+      //return the first value possible
+      return this.getOne(property);
+    }
+  }
+
+  getAllFromPath(...properties: NamedNode[]): NodeSet {
+    //we just need all paths, so we can do a breadth first implementation
+    //take first property
+    var property = properties.shift();
+
+    if (properties.length > 0) {
+      //and ask the whole set of values to return all values of the rest of the path
+      return this.getAll(property).getAllFromPath(...properties);
+    } else {
+      return this.getAll(property);
+    }
+  }
+
+  getOneInverse(property: NamedNode): NamedNode | undefined {
+    for (var node of this) {
+      if (node.hasInverseProperty(property)) {
+        return node.getOneInverse(property);
+      }
+    }
+    return undefined;
+  }
+
+  getAllInverse(property: NamedNode): NodeSet<NamedNode> {
+    var res = new NodeSet<NamedNode>();
+    for (var node of this) {
+      res = res.concat(node.getAllInverse(property));
+    }
+    return res;
+  }
+
+  getMultipleInverse(properties: ICoreIterable<NamedNode>): NodeSet {
+    var res = new NodeSet();
+    for (var instance of this) {
+      for (var property of properties) {
+        res = res.concat(instance.getAllInverse(property));
+      }
+    }
+    return res;
+  }
+
+  getMultiple(properties: ICoreIterable<NamedNode>): NodeSet {
+    var res = new NodeSet();
+    for (var node of this) {
+      for (var property of properties) {
+        res = res.concat(node.getAll(property));
+      }
+    }
+    return res;
+  }
+
+  getDeep(property: NamedNode, maxDepth: number = Infinity): NodeSet {
+    var result = new NodeSet();
+    var stack: NodeSet = this;
+    while (stack.size > 0 && maxDepth > 0) {
+      var nextLevelStack = new NodeSet();
+      for (let node of stack) {
+        for (var value of node.getAll(property)) {
+          if (!result.has(value)) {
+            result.add(value);
+            nextLevelStack.add(value);
+          }
+        }
+      }
+      stack = nextLevelStack;
+      maxDepth--;
+    }
+    return result;
+  }
+
+  getQuads(property: NamedNode): QuadSet {
+    var res = new QuadSet();
+    for (var node of this) {
+      for (var quad of node.getQuads(property)) {
+        res.add(quad);
+      }
+    }
+    return res;
+  }
+
+  getInverseQuads(property: NamedNode): QuadSet | any {
+    var res = new QuadSet();
+    for (var node of this) {
+      for (var quad of node.getInverseQuads(property)) {
+        res.add(quad);
+      }
+    }
+    return res;
+  }
+
+  getAllQuads(
+    includeAsObject?: boolean,
+    includeImplicit: boolean = false,
+  ): QuadArray {
+    var res = new QuadArray();
+    for (var node of this) {
+      for (var item of node.getAllQuads(includeAsObject, includeImplicit)) {
+        if (res.indexOf(item) === -1) {
+          res.push(item);
+        }
+      }
+      //res = res.concat(node.getAllQuads(includeAsObject));
+    }
+    return res;
+  }
+
+  getAllInverseQuads(includeImplicit?: boolean): QuadArray {
+    var res = new QuadArray();
+    for (var node of this) {
+      for (var item of node.getAllInverseQuads(includeImplicit)) {
+        if (res.indexOf(item) === -1) {
+          res.push(item);
+        }
+      }
+    }
+    return res;
+  }
+
+  where(property: NamedNode, value: Node): this {
+    //TODO: test performance with
+    //return this.filter(r => r.has(property,value));
+    var res = this.createNew();
+    for (var node of this) {
+      if (node.has(property, value)) {
+        //as any apparently needed, strange that NamedNode is not seen as matching to R?
+        res.add(node as any);
+      }
+    }
+    return res;
+  }
+
+  getWhere(property: NamedNode, value: Node): Node | undefined {
+    for (var node of this) {
+      if (node.has(property, value)) {
+        return node;
+      }
+    }
+    return undefined;
+  }
+
+  setEach(property: NamedNode, value: Node): boolean {
+    let res = false;
+    for (var node of this) {
+      res = node.set(property, value) && res;
+    }
+    return res;
+  }
+
+  msetEach(property: NamedNode, values: ICoreIterable<Node>): boolean {
+    let res = false;
+    for (var node of this) {
+      res = node.mset(property, values) && res;
+    }
+    return res;
+  }
+
+  updateEach(property: NamedNode, value: Node): boolean {
+    let res = false;
+    for (var node of this) {
+      res = node.overwrite(property, value) && res;
+    }
+    return res;
+  }
+
+  mupdateEach(property: NamedNode, values: ICoreIterable<Node>): boolean {
+    let res = false;
+    for (var node of this) {
+      res = node.moverwrite(property, values) && res;
+    }
+    return res;
+  }
+
+  unsetEach(property: NamedNode, value: Node): boolean {
+    let res = false;
+    for (var node of this) {
+      res = node.unset(property, value) && res;
+    }
+    return res;
+  }
+
+  unsetAllEach(property: NamedNode): boolean {
+    let res = false;
+    for (var node of this) {
+      res = node.unsetAll(property) && res;
+    }
+    return res;
+  }
+
+  //@TODO: remove generic isLoaded now that we have Shape loading functionality?
+
+  //@TODO: remove promiseLoaded now that we have Shape loading functionality?
+  /**
+   * @deprecated
+   * @param loadInverseProperties
+   */
+  promiseLoaded(loadInverseProperties: boolean = false): Promise<boolean> {
+    return Promise.all(
+      this.map((node) => node.promiseLoaded(loadInverseProperties)),
+    )
+      .then((res) => {
+        return res.every((result) => result === true);
+      })
+      .catch(() => {
+        return false;
+      });
+  }
+
+  // perhaps we need to add a new shapeIsLoaded() method?
+  /**
+   * @deprecated
+   * @param includingInverseProperties
+   */
+  isLoaded(includingInverseProperties: boolean = false): boolean {
+    return this.every((node) => node.isLoaded(includingInverseProperties));
+  }
+
+  toString(): string {
+    return (
+      'NodeSet {\n' +
+      [...this].map((node) => '\t' + node.toString()).join(',\n') +
+      '\n}'
+    );
+  }
+
+  print(includeIncomingProperties: boolean = true) {
+    return Debug.print(this, includeIncomingProperties);
+  }
+}

--- a/rebrand/linked-mem-store/src/collections/NodeURIMappings.ts
+++ b/rebrand/linked-mem-store/src/collections/NodeURIMappings.ts
@@ -1,0 +1,63 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+import {BlankNode,NamedNode} from '../models.js';
+import {NodeMap} from './NodeMap.js';
+import {NodeSet} from './NodeSet.js';
+
+//TODO: rename to something more fitting now that it also handles TMP NamedNodes
+export class NodeURIMappings extends NodeMap<NamedNode> {
+  originalUris: Map<string, string> = new Map();
+
+  /**
+   * Will create a blanknode the first time you give a certain URI
+   * and return the same blanknode when you request it again.
+   * Note that the blanknode itself will have its own local URI regardless of the give URI
+   * this method allows you to parse a set of data that
+   * uses a certain identifier for a certain blanknode across several places
+   * and convert it to a local blanknode
+   * @param {string} givenUri
+   * @returns {BlankNode}
+   */
+  getOrCreateBlankNode(givenUri: string): BlankNode {
+    //TODO: rename this method to getOrCreateBlankNode
+    if (this.has(givenUri)) {
+      return this.get(givenUri);
+    } else {
+      var blankNode: BlankNode = new BlankNode();
+      this.set(givenUri, blankNode);
+      this.originalUris.set(blankNode.uri, givenUri);
+      return blankNode;
+    }
+  }
+
+  getBlankNodes(): NodeSet<BlankNode> {
+    return new NodeSet(this.filter((n) => n instanceof BlankNode).values());
+  }
+
+  getOrCreateNamedNode(uri: string): NamedNode {
+    //the temp URI's in one environment may already be used in another environment
+    //so we need to check for temporary URI's and convert them to a local temporary URI
+    if (
+      uri.substring(0, NamedNode.TEMP_URI_BASE.length) ==
+      NamedNode.TEMP_URI_BASE
+    ) {
+      if (!this.has(uri)) {
+        //create a new temp node that has a LOCAL temp URI
+        var tmpResource: NamedNode = NamedNode.create();
+        this.set(uri, tmpResource);
+        this.originalUris.set(tmpResource.uri, uri);
+        return tmpResource;
+      }
+      return this.get(uri);
+    }
+    return NamedNode.getOrCreate(uri);
+  }
+
+  getOriginalUri(localUri: string) {
+    //return the original uri, and if we dont have a mapping it will not have changed
+    return this.originalUris.get(localUri) || localUri;
+  }
+}

--- a/rebrand/linked-mem-store/src/collections/NodeValuesSet.ts
+++ b/rebrand/linked-mem-store/src/collections/NodeValuesSet.ts
@@ -1,0 +1,122 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+import {NodeSet} from './NodeSet.js';
+import {NamedNode,Node} from '../models.js';
+import {QuadSet} from './QuadSet.js';
+
+export class NodeValuesSet extends NodeSet {
+  constructor(
+    private _subject: Node,
+    private _property: NamedNode,
+    iterable?: Iterable<Node>,
+  ) {
+    super(iterable);
+  }
+
+  get subject() {
+    return this._subject;
+  }
+
+  get property() {
+    return this._property;
+  }
+
+  /**
+   * Listen to any changes in the valueset for this subject + property combination
+   * If you provide context (usually 'this'), removing the onChange listener will remove all listeners for this property & context, regardless of what callback you provide. (this is helpful if you dont have access to the excact same callback function)
+   * @param callback
+   * @param context
+   */
+  onChange(
+    callback: (quads?: QuadSet, property?: NamedNode) => void,
+    context?,
+  ) {
+    (this._subject as NamedNode).onChange(this._property, callback, context);
+  }
+
+  /**
+   * Remove listener for changes in the valueset for this subject + property combination
+   * If you provide context (usually 'this'), removing the onChange listener will remove all listeners for this property & context, regardless of what callback you provide. (this is helpful if you dont have access to the excact same callback function)
+   * @param callback
+   * @param context
+   */
+  removeOnChange(
+    callback: (quads?: QuadSet, property?: NamedNode) => void,
+    context?,
+  ) {
+    (this._subject as NamedNode).removeOnChange(
+      this._property,
+      callback,
+      context,
+    );
+  }
+
+  /**
+   * When cloned we switch to a NodeSet of all the values
+   * And detach from the magic of PropertyValueSets, which are only meant to be used internally in the NamedNode model
+   * @param args
+   */
+  createNew(...args): any {
+    return new NodeSet(...args);
+  }
+
+  /**
+   * Add a new node to this set of values.
+   * This creates a new quad in the local graph.
+   * This is equivalent to manually adding a new property value using `subject.set(predicate,object)`
+   * @param value the node to add
+   */
+  add(value: Node): this {
+    this._subject.set(this._property, value);
+    return this;
+  }
+
+  /**
+   * Remove a node from this set of values.
+   * This removes a quad in the local graph (if the node was an existing value)
+   * This is equivalent to manually removing a property value using `subject.unset(predicate,object)`
+   * @param value the node to remove
+   */
+  delete(value: Node): boolean {
+    return this._subject.unset(this._property, value);
+  }
+
+  /**
+   * Actually removes a node from this value set. Does not remove any quads in the local graph
+   * DO NOT use this method.
+   * Use subject.getAll(predicate).remove(object) or subject.unset(predicate,object) instead
+   * @internal
+   * @param v
+   */
+  __delete(v) {
+    return super.delete(v);
+  }
+
+  /**
+   * Adds a value directly to this value set. Does not create new quads in the local graph
+   * DO NOT USE this method.
+   * Use subject.getAll(predicate).add(object) or subject.set(predicate,object) instead.
+   * @internal
+   * @param v
+   */
+  __add(v) {
+    return super.add(v);
+  }
+
+  //here we overload the type definitions to indicate its a NodeSet that will be returned
+  //HOWEVER, without '|any' this will not be expected by Typescript unless we find a really intricate way of rewriting all methods of CoreSet / CoreIterable that return this into methods that return ...?
+  sort(compareFn?, thisArg?): NodeSet | any {
+    return super.sort(compareFn, thisArg) as NodeSet;
+  }
+
+  concat(...sets): NodeSet | any {
+    return super.concat(...sets) as NodeSet;
+  }
+
+  filter(fn): this {
+    return super.filter(fn) as NodeSet | any;
+  }
+}

--- a/rebrand/linked-mem-store/src/collections/QuadArray.ts
+++ b/rebrand/linked-mem-store/src/collections/QuadArray.ts
@@ -1,0 +1,81 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+import {Graph,NamedNode,Quad} from '../models.js';
+import {NodeSet} from './NodeSet.js';
+
+//TODO: test performance of QuadArray vs QuadSet and probably remove QuadArray
+export class QuadArray extends Array<Quad> {
+  removeAll(alteration: boolean = false) {
+    this.forEach((quad) => quad.remove(alteration));
+  }
+
+  moveTo(graph: Graph, alteration: boolean = true): QuadArray {
+    let result = new QuadArray();
+    this.forEach((quad) => {
+      result.push(quad.moveToGraph(graph, alteration));
+    });
+    return result;
+  }
+
+  makeExplicit() {
+    this.forEach((quad) => quad.makeExplicit());
+  }
+
+  getSubjects(): NodeSet<NamedNode> {
+    //return new NamedNodeSet(this.map(quad => quad.subject).values());
+    //that's short, but probably this is faster:
+    var res = new NodeSet<NamedNode>();
+    for (var quad of this) {
+      res.add(quad.subject);
+    }
+    return res;
+  }
+
+  getPredicates(): NodeSet<NamedNode> {
+    var res = new NodeSet<NamedNode>();
+    for (var quad of this) {
+      res.add(quad.predicate);
+    }
+    return res;
+  }
+
+  getObjects(): NodeSet {
+    var res = new NodeSet();
+    for (var quad of this) {
+      res.add(quad.object);
+    }
+    return res;
+  }
+
+  map<S>(callbackfn: (value: Quad, index: number, array: Quad[]) => S): S[] {
+    return super.map(callbackfn);
+  }
+
+  getExplicit() {
+    return this.filter((quad) => !quad.implicit);
+  }
+
+  getImplicit() {
+    return this.filter((quad) => quad.implicit);
+  }
+
+  turnOn() {
+    this.forEach((quad) => quad.turnOn());
+  }
+
+  turnOff() {
+    this.forEach((quad) => quad.turnOff());
+  }
+
+  toString() {
+    //without this the toString() would print 3 URI's for each quad followed by a ',' which looks messy and unclear
+    return this.join('\n');
+  }
+
+  print() {
+    console.log(this.toString());
+  }
+}

--- a/rebrand/linked-mem-store/src/collections/QuadMap.ts
+++ b/rebrand/linked-mem-store/src/collections/QuadMap.ts
@@ -1,0 +1,198 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+import {NamedNode,Node,Quad} from '../models.js';
+import {NodeSet} from './NodeSet.js';
+import {QuadSet} from './QuadSet.js';
+import {CoreSet} from './CoreSet.js';
+import {ICoreIterable} from '../interfaces/ICoreIterable.js';
+
+/**
+ * A map who's values are sets
+ * When you iterate over this map with methods like map and forEach you'll iterate over the values of the sets
+ */
+class CoreMapToSet<K, S extends CoreSet<V>, V>
+  extends Map<K, S>
+  implements ICoreIterable<V>
+{
+  /**
+   * Determines whether all the members of an array satisfy the specified test.
+   * @param callbackfn A function that accepts up to three arguments. The every method calls the callbackfn function for each element in array1 until the callbackfn returns false, or until the end of the array.
+   * @param thisArg An object to which the this keyword can refer in the callbackfn function. If thisArg is omitted, undefined is used as the this value.
+   */
+  every(
+    callbackfn: (value: V, key: K, map: CoreMapToSet<K, S, V>) => boolean,
+    thisArg?: any,
+  ): boolean {
+    for (let [key, set] of this) {
+      for (let value of set) {
+        if (!callbackfn.apply(thisArg, [value, key, this])) {
+          return false;
+        }
+      }
+    }
+    return true;
+  }
+
+  /**
+   * This object is a Map whos values are sets.
+   * This forEach method calls the callback-function for each items in each of those sets.
+   * The first parameter has the type of the items in the sets
+   * The second parameter is the key
+   * The type information can unfortunately not be defined as they would conflict with the usual forEach method
+   * @param callbackfn
+   * @param thisArg
+   */
+  forEach(
+    callbackfn: (value: any, key: any, map: any) => void,
+    thisArg?: any,
+  ): void {
+    for (let [key, set] of this) {
+      for (let value of set) {
+        callbackfn.apply(thisArg, [value, key, this]);
+      }
+    }
+  }
+
+  /**
+   * Determines whether the specified callback function returns true for any element of an array.
+   * @param callbackfn A function that accepts up to three arguments. The some method calls the callbackfn function for each element in array1 until the callbackfn returns true, or until the end of the array.
+   * @param thisArg An object to which the this keyword can refer in the callbackfn function. If thisArg is omitted, undefined is used as the this value.
+   */
+  some(
+    callbackfn: (value: V, key: K, set: S, map: this) => boolean,
+    thisArg?: any,
+  ): boolean {
+    for (let [key, set] of this) {
+      for (let value of set) {
+        if (callbackfn.apply(thisArg, [value, key, set, this])) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Maps all values contained in this map of set into a new single set
+   * @param callbackfn A function that accepts up to three arguments. The map method calls the callbackfn function one time for each element in the array.
+   * @param thisArg An object to which the this keyword can refer in the callbackfn function. If thisArg is omitted, undefined is used as the this value.
+   */
+  map<R extends CoreSet<any>>(
+    callbackfn: (value: V, key: K, set: S, map: this) => any,
+    resultType: typeof CoreSet = CoreSet,
+    thisArg?: any,
+  ): R {
+    //create the result map, whos values will be 'mapped' into new values from the current values of this map
+    //whilst maintaining set organisation
+    var resultSet: CoreSet<any> = new resultType();
+    for (let [key, set] of this) {
+      for (let value of set) {
+        //get the right set and add the mapped value to it
+        resultSet.add(callbackfn.apply(thisArg, [value, key, set, this]));
+      }
+    }
+    return resultSet as R;
+  }
+
+  /**
+   * Returns the end values in the map that meet the condition specified in a callback function.
+   * The result will be a single set of values
+   * @param callbackfn A function that accepts up to three arguments. The filter method calls the callbackfn function one time for each element in the array.
+   * @param thisArg An object to which the this keyword can refer in the callbackfn function. If thisArg is omitted, undefined is used as the this value.
+   */
+  filter<R extends CoreSet<any>>(
+    callbackfn: (value: V, key: K, set: S, map: this) => any,
+    resultType: typeof CoreSet = CoreSet,
+    thisArg?: any,
+  ): R {
+    //create the result map, whos values will be 'mapped' into new values from the current values of this map
+    //whilst maintaining set organisation
+    var resultSet: CoreSet<any> = new resultType();
+    for (let [key, set] of this) {
+      //use the type of the first set to determine the result type
+      for (let value of set) {
+        //if the filter function returns true-ish
+        if (callbackfn.apply(thisArg, [value, key, set, this])) {
+          //add to result set
+          resultSet.add(value);
+        }
+      }
+    }
+    return resultSet as R;
+  }
+
+  first(): V | null {
+    return this.values().next().value.first();
+  }
+
+  /**
+   * Returns the value of the first element in the Set where predicate is true, and undefined
+   * otherwise.
+   */
+  find(
+    predicate: (value: V, index: K, set: S) => boolean,
+    thisArg?: any,
+  ): V | undefined {
+    for (let [key, set] of this) {
+      for (let value of set) {
+        if (predicate.apply(thisArg, [value, key, this])) {
+          return value;
+        }
+      }
+    }
+    return undefined;
+  }
+
+  toString() {
+    let res = 'MapToSets:\n';
+    for (let [key, set] of this) {
+      res += '\t[' + key.toString() + '] => ' + set.toString() + '\n';
+    }
+    return res;
+  }
+}
+
+export class QuadMap extends CoreMapToSet<Node, QuadSet, Quad> {
+  removeAll(alteration: boolean = false) {
+    this.forEach((quad) => quad.remove(alteration));
+  }
+
+  getSubjects(): NodeSet<NamedNode> {
+    return this.map((quad) => quad.subject, NodeSet) as NodeSet<NamedNode>;
+  }
+
+  getPredicates(): NodeSet<NamedNode> {
+    return this.map((quad) => quad.predicate, NodeSet) as NodeSet<NamedNode>;
+  }
+
+  getObjects(): NodeSet {
+    return this.map((quad) => quad.predicate, NodeSet);
+  }
+
+  getQuadSet(): QuadSet {
+    return this.map((q) => q, QuadSet);
+  }
+
+  delete(v): boolean {
+    throw new Error(
+      'Do not delete values directly from a QuadMap. Either create a new set of all values with getQuadSet() or use methods like map() and filter() which also return a new set.',
+    );
+    return false;
+  }
+
+  __delete(v) {
+    return super.delete(v);
+  }
+
+  __set(k: Node, v: Quad) {
+    //make sure we have a QuadSet ready for that key
+    if (!this.has(k)) {
+      this.set(k, new QuadSet());
+    }
+    //then add this quad to that set
+    this.get(k).add(v);
+  }
+}

--- a/rebrand/linked-mem-store/src/collections/QuadSet.ts
+++ b/rebrand/linked-mem-store/src/collections/QuadSet.ts
@@ -1,0 +1,131 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+//declare var require:Function;
+//require('core-js/fn/set');
+//import * as Set from 'core-js/es6/set';
+import {Graph,NamedNode,Node,Quad} from '../models.js';
+import {CoreSet} from './CoreSet.js';
+import {NodeSet} from './NodeSet.js';
+
+export class QuadSet extends CoreSet<Quad> {
+  removeAll(alteration: boolean = false) {
+    this.forEach((quad) => quad.remove(alteration));
+  }
+
+  moveTo(graph: Graph, alteration: boolean = true): QuadSet {
+    let newSet = new QuadSet();
+    this.forEach((quad) => {
+      newSet.add(quad.moveToGraph(graph, alteration));
+    });
+    return newSet;
+  }
+
+  makeExplicit() {
+    this.forEach((quad) => quad.makeExplicit());
+  }
+
+  getSubjects(): NodeSet<NamedNode> {
+    //return new NamedNodeSet(this.map(quad => quad.subject).values());
+    //that's short, but probably this is faster:
+    var res = new NodeSet<NamedNode>();
+    for (var quad of this) {
+      res.add(quad.subject);
+    }
+    return res;
+  }
+
+  getPredicates(): NodeSet<NamedNode> {
+    var res = new NodeSet<NamedNode>();
+    for (var quad of this) {
+      res.add(quad.predicate);
+    }
+    return res;
+  }
+
+  getObjects(): NodeSet {
+    var res = new NodeSet();
+    for (var quad of this) {
+      res.add(quad.object);
+    }
+    return res;
+  }
+
+  getNamedNodeObjects(): NodeSet<NamedNode> {
+    var res = new NodeSet<NamedNode>();
+    for (var quad of this) {
+      //using instanceof NamedNode here will cause circular references
+      if ('uri' in quad.object) {
+        res.add(quad.object as NamedNode);
+      }
+    }
+    return res;
+  }
+
+  getLiteralObjects(): NodeSet {
+    var res = new NodeSet();
+    for (var quad of this) {
+      //using instanceof Literal here will cause circular references
+      if (!('uri' in quad.object)) {
+        res.add(quad.object);
+      }
+    }
+    return res;
+  }
+
+  getLike(subject?: NamedNode, predicate?: NamedNode, object?: Node): this {
+    return this.filter((quad) => {
+      return (
+        (!subject || quad.subject === subject) &&
+        (!predicate || quad.predicate === predicate) &&
+        (!object || quad.object === object)
+      );
+    });
+  }
+
+  getNamedNodes(): NodeSet<NamedNode> {
+    return new NodeSet<NamedNode>()
+      .concat(this.getSubjects())
+      .concat(this.getPredicates())
+      .concat(this.getNamedNodeObjects());
+  }
+
+  getNodes(): NodeSet {
+    return new NodeSet()
+      .concat(this.getSubjects())
+      .concat(this.getPredicates())
+      .concat(this.getObjects());
+  }
+
+  hasNode(node: Node) {
+    return this.some((quad) => {
+      return (
+        quad.subject === node || quad.predicate === node || quad.object === node
+      );
+    });
+  }
+
+  getExplicit() {
+    return this.filter((quad) => !quad.implicit);
+  }
+
+  getImplicit() {
+    return this.filter((quad) => quad.implicit);
+  }
+
+  turnOn() {
+    return this.forEach((t) => t.turnOn());
+  }
+
+  turnOff() {
+    return this.forEach((t) => t.turnOff());
+  }
+
+  toString() {
+    var str = '';
+    this.forEach((item) => (str += '\t' + item.toString() + '\n'));
+    return 'QuadSet(' + this.size + ') [\n' + str + ']';
+  }
+}

--- a/rebrand/linked-mem-store/src/events/EventBatcher.ts
+++ b/rebrand/linked-mem-store/src/events/EventBatcher.ts
@@ -1,0 +1,108 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+import nextTick from 'next-tick';
+import {EventEmitter} from 'eventemitter3';
+import {CoreSet} from '../collections/CoreSet.js';
+
+//import {CoreMap} from "../collections/CoreMap";
+
+export interface BatchedEventEmitter {
+  emitBatchedEvents(resolve?: any, reject?: any): void;
+}
+
+export class EventBatcher extends EventEmitter {
+  static ALL_EVENTS_DISPATCHED: string = 'ALL_EVENTS_DISPATCHED';
+  emitters: CoreSet<BatchedEventEmitter> = new CoreSet<BatchedEventEmitter>();
+  private batching: boolean = false;
+  private emitting: boolean;
+
+  get isBatching() {
+    return this.batching;
+  }
+
+  hasBatchedEvents(
+    filterFn?: (emitter: BatchedEventEmitter) => boolean,
+  ): boolean {
+    if (filterFn && this.batching) {
+      return this.emitters.filter(filterFn).size > 0;
+    }
+    return this.batching;
+  }
+
+  getPendingEmitters(
+    filterFn?: (emitter: BatchedEventEmitter) => boolean,
+  ): CoreSet<BatchedEventEmitter> {
+    if (filterFn && this.batching) {
+      return this.emitters.filter(filterFn);
+    }
+    return this.emitters;
+  }
+
+  promiseDone() {
+    if (this.emitters.size == 0) {
+      return Promise.resolve(true);
+    } else {
+      return new Promise((resolve, reject) => {
+        this.once(EventBatcher.ALL_EVENTS_DISPATCHED, () => {
+          resolve(true);
+        });
+      });
+    }
+  }
+
+  dispatchBatchedEventsOnceReady() {
+    //if we're currently emitting events, then we dont want to do nextTick yet, because those who consume events may want to set nextTick first
+    if (this.emitting) {
+      //so once all is dispatched, then we dispatch again
+      this.once(EventBatcher.ALL_EVENTS_DISPATCHED, () => {
+        nextTick(this.dispatchBatchedEvents.bind(this));
+      });
+    } else {
+      //we're already not emitting, so on the next tick we can dispatch events
+      nextTick(this.dispatchBatchedEvents.bind(this));
+    }
+  }
+
+  dispatchBatchedEvents() {
+    //reset things before emitting so that new events will be added to new stacks
+    var toEmit = this.emitters;
+    this.emitters = new CoreSet();
+    this.batching = false;
+    this.emitting = true;
+
+    //tell all emitters to dispatch
+    toEmit.forEach((emitter) => {
+      emitter.emitBatchedEvents();
+    });
+    this.emitting = false;
+    this.emit(EventBatcher.ALL_EVENTS_DISPATCHED);
+  }
+
+  dispatchSomeEvents(
+    filterEmitters: (emitter: BatchedEventEmitter) => boolean,
+  ) {
+    //tell all emitters to dispatch
+    this.emitters.forEach((emitter) => {
+      if (filterEmitters(emitter)) {
+        emitter.emitBatchedEvents();
+        this.emitters.delete(emitter);
+      }
+    });
+    this.batching = this.emitters.size > 0;
+    return this.batching;
+  }
+
+  register(emitter: BatchedEventEmitter) {
+    //first time someone registers an event we will make sure to emit all batched events at the next tick
+    if (!this.batching) {
+      this.batching = true;
+      this.dispatchBatchedEventsOnceReady();
+    }
+    this.emitters.add(emitter);
+  }
+}
+
+export const eventBatcher = new EventBatcher();

--- a/rebrand/linked-mem-store/src/events/EventEmitter.ts
+++ b/rebrand/linked-mem-store/src/events/EventEmitter.ts
@@ -1,0 +1,139 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+import {EventEmitter as EventEmitter3} from 'eventemitter3';
+
+var prefix = EventEmitter3['prefixed'];
+
+export class EventEmitter extends EventEmitter3 {
+  /**
+   * @internal
+   * @protected
+   */
+  protected _events: any;
+  /**
+   * @internal
+   * @protected
+   */
+  protected _eventsCount: number;
+
+  emitPromise(evt: string | symbol, a1?, a2?, a3?, a4?, a5?): Promise<any> {
+    //BASED ON eventemitter3 implementation of emit
+    //But I removed prefix functionality and listeners.fn
+    //And then added support for promises
+
+    if (!this._events[evt]) return Promise.resolve();
+
+    var listeners = this._events[evt],
+      len = arguments.length,
+      args,
+      i;
+
+    if (listeners.fn) {
+      listeners = [listeners];
+    }
+    //ignored listeners.fn
+    var length = listeners.length,
+      j;
+
+    let listenerPromises = [];
+    for (i = 0; i < length; i++) {
+      if (listeners[i].once)
+        this.removeListener(evt, listeners[i].fn, undefined, true);
+
+      switch (len) {
+        case 1:
+          listenerPromises.push(listeners[i].fn.call(listeners[i].context));
+          break;
+        case 2:
+          listenerPromises.push(listeners[i].fn.call(listeners[i].context, a1));
+          break;
+        case 3:
+          listenerPromises.push(
+            listeners[i].fn.call(listeners[i].context, a1, a2),
+          );
+          break;
+        case 4:
+          listenerPromises.push(
+            listeners[i].fn.call(listeners[i].context, a1, a2, a3),
+          );
+          break;
+        default:
+          if (!args)
+            for (j = 1, args = new Array(len - 1); j < len; j++) {
+              args[j - 1] = arguments[j];
+            }
+
+          listenerPromises.push(
+            listeners[i].fn.apply(listeners[i].context, args),
+          );
+      }
+    }
+    return Promise.all(listenerPromises).catch(function (err) {
+      console.log(
+        'Error during emitPromise of event ' +
+          evt.toString() +
+          ' with args ' +
+          JSON.stringify(arguments),
+        err.toString(),
+      );
+    });
+  }
+
+  removeListenerByContext(
+    event: string | symbol,
+    context?: any,
+    once?: boolean,
+  ): this {
+    //copied from source and adjusted
+    var evt = prefix && typeof event === 'string' ? prefix + event : event;
+
+    if (!this._events[evt]) return this;
+    var listeners = this._events[evt];
+
+    //make a list of events to keep:
+    //if a single listener is registered
+    let eventsToKeep;
+
+    if (listeners.fn) {
+      //check if 'once' and 'context' match
+      if (
+        (once && !listeners.fn.once) ||
+        (context && listeners.fn.context !== context)
+      ) {
+        //if not we keep it 'as is'
+        eventsToKeep = listeners;
+      }
+    } else if (listeners) {
+      eventsToKeep = [];
+      //if there's an array of listeners, go over each
+      for (var i = 0, length = listeners.length; i < length; i++) {
+        //check if 'once' and 'context' match
+        if (
+          (once && !listeners[i].once) ||
+          (context && listeners[i].context !== context)
+        ) {
+          //if not, keep this single listener
+          eventsToKeep.push(listeners[i]);
+        }
+      }
+    }
+
+    // update events and events count
+    if (eventsToKeep) {
+      //take the one event, or, if its an array, take the array, unless theres only one element left, then just use that directly
+      this._events[evt] = eventsToKeep.fn
+        ? eventsToKeep
+        : eventsToKeep.length === 1
+          ? eventsToKeep[0]
+          : eventsToKeep;
+    } else {
+      --this._eventsCount;
+      delete this._events[evt];
+    }
+
+    return this;
+  }
+}

--- a/rebrand/linked-mem-store/src/index.ts
+++ b/rebrand/linked-mem-store/src/index.ts
@@ -13,11 +13,18 @@ export * from './collections/NodeValuesSet.js';
 export * from './events/EventEmitter.js';
 export * from './events/EventBatcher.js';
 
+export {rdf} from './ontologies/rdf.js';
+export {xsd} from './ontologies/xsd.js';
+
 export * from './interfaces/ICoreIterable.js';
 export * from './interfaces/IGraphObject.js';
 export * from './interfaces/IGraphObjectSet.js';
 export * from './interfaces/IShape.js';
+export * from './interfaces/IQuadStore.js';
 
 export * from './utils/Debug.js';
 export * from './utils/Prefix.js';
 export * from './utils/URI.js';
+export * from './utils/LocalQueryResolver.js';
+
+export * from './stores/InMemoryStore.js';

--- a/rebrand/linked-mem-store/src/index.ts
+++ b/rebrand/linked-mem-store/src/index.ts
@@ -1,0 +1,23 @@
+export * from './models.js';
+
+export * from './collections/CoreSet.js';
+export * from './collections/CoreMap.js';
+export * from './collections/QuadMap.js';
+export * from './collections/QuadArray.js';
+export * from './collections/QuadSet.js';
+export * from './collections/NodeSet.js';
+export * from './collections/NodeMap.js';
+export * from './collections/NodeURIMappings.js';
+export * from './collections/NodeValuesSet.js';
+
+export * from './events/EventEmitter.js';
+export * from './events/EventBatcher.js';
+
+export * from './interfaces/ICoreIterable.js';
+export * from './interfaces/IGraphObject.js';
+export * from './interfaces/IGraphObjectSet.js';
+export * from './interfaces/IShape.js';
+
+export * from './utils/Debug.js';
+export * from './utils/Prefix.js';
+export * from './utils/URI.js';

--- a/rebrand/linked-mem-store/src/interfaces/ICoreIterable.ts
+++ b/rebrand/linked-mem-store/src/interfaces/ICoreIterable.ts
@@ -1,0 +1,35 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+/**
+ * Pretty open and general interface that closely resembles JS Arrays.
+ * other classes like CoreMap and CoreSet can implement this so that we know which methods are available
+ */
+//extending Iterable<ANY> because Maps and Sets use different iterator setups that would not match with type definitions
+//this allows us to still use iterators for ICoreIterable but without typing information, although for all methods below it works
+export interface ICoreIterable<V> extends Iterable<any> {
+  forEach: (
+    callbackFn: (item: V, index?: any, iterable?: any) => void,
+    context?: any,
+  ) => void;
+  size?: number;
+  length?: number;
+
+  filter(
+    callbackfn: (value: V, index: any, thisInstance: any) => any,
+    thisArg?: any,
+  ): Iterable<any>;
+
+  find(
+    predicate: (value: V, index: any, obj: ICoreIterable<V>) => boolean,
+    thisArg?: any,
+  ): V | undefined;
+
+  every(callbackfn: (item: V) => boolean, thisArg?: any): boolean;
+
+  some(callbackfn: (item: V) => boolean, thisArg?: any): boolean;
+
+  map<U>(callbackfn: (item: V) => U, thisArg?: any): any;
+}

--- a/rebrand/linked-mem-store/src/interfaces/IGraphObject.ts
+++ b/rebrand/linked-mem-store/src/interfaces/IGraphObject.ts
@@ -1,0 +1,59 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+import {NamedNode,Node} from '../models.js';
+import {NodeSet} from '../collections/NodeSet.js';
+import {QuadSet} from '../collections/QuadSet.js';
+import {QuadArray} from '../collections/QuadArray.js';
+import {ICoreIterable} from './ICoreIterable.js';
+
+export interface IGraphObject {
+  getProperties(
+    includeFromIncomingArcs?: boolean,
+    includeImplicitFacts?: boolean,
+  ): NodeSet<NamedNode>;
+
+  getInverseProperties(): NodeSet<NamedNode>;
+
+  /**
+   * Returns the first property value, if any
+   * For sets, returns the first property value for the first node that has values for this property
+   * @param property
+   */
+  getOne(property: NamedNode): Node | undefined;
+
+  getOneInverse(property: NamedNode): NamedNode | undefined;
+
+  getAll(property: NamedNode): NodeSet;
+
+  getAllInverse(property: NamedNode): NodeSet<NamedNode>;
+
+  getMultiple(properties: ICoreIterable<NamedNode>): NodeSet;
+
+  getMultipleInverse(properties: ICoreIterable<NamedNode>): NodeSet;
+
+  getDeep(
+    property: NamedNode,
+    maxDepth?: number,
+    partialResult?: NodeSet,
+  ): NodeSet;
+
+  //TODO: since the implementation of these methods is pretty much the same across all classes that implement IGraphObjects maybe it should be moved to Find or another UTIL to avoid repeating ourselves
+  getOneFromPath(...properties: NamedNode[]): Node | undefined;
+
+  getAllFromPath(...properties: NamedNode[]): NodeSet;
+
+  getQuads(property: NamedNode, value?: Node): QuadSet;
+
+  getInverseQuads(property: NamedNode): QuadSet;
+
+  getAllQuads(includeAsObject?: boolean, includeImplicit?: boolean): QuadArray;
+
+  getAllInverseQuads(includeImplicit?: boolean): QuadArray;
+
+  isLoaded(includingIncomingProperties?: boolean): boolean;
+
+  promiseLoaded(loadInverseProperties?: boolean): Promise<boolean>;
+}

--- a/rebrand/linked-mem-store/src/interfaces/IGraphObjectSet.ts
+++ b/rebrand/linked-mem-store/src/interfaces/IGraphObjectSet.ts
@@ -1,0 +1,40 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+import {NamedNode,Node} from '../models.js';
+import {NodeSet} from '../collections/NodeSet.js';
+import {QuadSet} from '../collections/QuadSet.js';
+import {IGraphObject} from './IGraphObject.js';
+import {ICoreIterable} from './ICoreIterable.js';
+
+/**
+ * a set of objects that all have IGraphObject methods, and this set itself also has those methods so you can call them directly on the set instead of for each item
+ */
+export interface IGraphObjectSet<R extends IGraphObject>
+  extends IGraphObject,
+    ICoreIterable<R> {
+  getQuads(property: NamedNode): QuadSet; //other then a single node, a set always returns a QuadSet, optionally empty
+  getInverseQuads(property: NamedNode): QuadSet; //other then a single node, a set always returns a QuadSet, optionally empty
+  getAll(property: NamedNode): NodeSet; //always returns a set
+  getAllInverse(property: NamedNode): NodeSet<NamedNode>; //always returns a set
+
+  //@NOTE: this interface intentionally does not contain has() or allHave() or someHave(),
+  //these should be written as set.some(item => item.has())
+
+  setEach(property: NamedNode, value: Node): boolean;
+
+  msetEach(property: NamedNode, values: ICoreIterable<Node>): boolean;
+
+  updateEach(property: NamedNode, value: Node): boolean;
+
+  mupdateEach(property: NamedNode, values: ICoreIterable<Node>): boolean;
+
+  unsetEach(property: NamedNode, value: Node): boolean;
+
+  /**
+   * Unset all values for the given property for each item in the set
+   * @param property
+   */
+  unsetAllEach(property: NamedNode): boolean;
+}

--- a/rebrand/linked-mem-store/src/interfaces/IQuadStore.ts
+++ b/rebrand/linked-mem-store/src/interfaces/IQuadStore.ts
@@ -1,0 +1,63 @@
+import type {QuadSet} from '../collections/QuadSet.js';
+import type {Graph, NamedNode, Quad} from '../models.js';
+import type {NodeSet} from '../collections/NodeSet.js';
+import type {ICoreIterable} from './ICoreIterable.js';
+import type {CoreMap} from '../collections/CoreMap.js';
+import type {QuadArray} from '../collections/QuadArray.js';
+import type {CreateQuery} from 'linked-js/queries/CreateQuery.js';
+import type {DeleteQuery} from 'linked-js/queries/DeleteQuery.js';
+import type {SelectQuery} from 'linked-js/queries/SelectQuery.js';
+import type {UpdateQuery} from 'linked-js/queries/UpdateQuery.js';
+
+export interface IQuadStore {
+  /**
+   * Prepares the store to be used.
+   */
+  init?(): Promise<any>;
+
+  updateQuery?<RType>(q: UpdateQuery<RType>): Promise<RType>;
+  createQuery?<R>(q: CreateQuery<R>): Promise<R>;
+  selectQuery<ResultType>(query: SelectQuery): Promise<ResultType>;
+
+  deleteQuery?(query: DeleteQuery): Promise<unknown>;
+
+  /** @deprecated Legacy quad-level API. */
+  update?(
+    toAdd: ICoreIterable<Quad>,
+    toRemove: ICoreIterable<Quad>,
+  ): Promise<any>;
+
+  /** @deprecated Legacy quad-level API. */
+  add?(quad: Quad): Promise<any>;
+
+  /** @deprecated Legacy quad-level API. */
+  addMultiple?(quads: QuadSet): Promise<any>;
+
+  /** @deprecated Legacy quad-level API. */
+  delete?(quad: Quad): Promise<any>;
+
+  /** @deprecated Legacy quad-level API. */
+  deleteMultiple?(quads: QuadSet): Promise<any>;
+
+  /** @deprecated Legacy URI management API. */
+  setURIs?(
+    nodeToCurrentUriMap: CoreMap<NamedNode, string>,
+  ): Promise<[string, string][]>;
+
+  /** @deprecated Legacy graph API. */
+  getDefaultGraph?(): Graph;
+
+  /** @deprecated Legacy cleanup API. */
+  removeNodes?(nodes: ICoreIterable<NamedNode>, quads?: QuadSet): Promise<any>;
+
+  /** @deprecated Legacy quad-level API. */
+  clearProperties?(
+    subjectToPredicates: CoreMap<NamedNode, NodeSet<NamedNode>>,
+  ): Promise<boolean>;
+
+  /** @deprecated Legacy load API. */
+  loadShape?(shapeInstance: any, shape: any): Promise<QuadArray>;
+
+  /** @deprecated Legacy load API. */
+  loadShapes?(shapeSet: any, shape: any): Promise<QuadArray>;
+}

--- a/rebrand/linked-mem-store/src/interfaces/IShape.ts
+++ b/rebrand/linked-mem-store/src/interfaces/IShape.ts
@@ -1,0 +1,46 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+import {IGraphObject} from './IGraphObject.js';
+import {NamedNode,Node} from '../models.js';
+import {ICoreIterable} from './ICoreIterable.js';
+
+export interface IShape extends IGraphObject {
+  namedNode: NamedNode;
+  node: Node;
+
+  set(property: NamedNode, value: Node): boolean;
+
+  mset(property: NamedNode, values: ICoreIterable<Node>): boolean;
+
+  overwrite(property: NamedNode, value: Node): boolean;
+
+  moverwrite(property: NamedNode, values: ICoreIterable<Node>): boolean;
+
+  unset(property: NamedNode, value: Node): boolean;
+
+  unsetAll(property: NamedNode): boolean;
+
+  hasExact(property: NamedNode, value: Node): boolean;
+
+  has(property: NamedNode, value: Node): boolean;
+
+  hasProperty(property: NamedNode): boolean;
+
+  hasInverseProperty(property: NamedNode): boolean;
+
+  hasInverse(property: NamedNode, value: Node): boolean;
+
+  hasPath(properties: NamedNode[]): boolean;
+
+  hasPathTo(properties: NamedNode[], value?: Node): boolean;
+
+  hasPathToSomeInSet(
+    properties: NamedNode[],
+    endPoints?: ICoreIterable<Node>,
+  ): boolean;
+
+  hasExplicit(property: NamedNode, value: Node): boolean;
+}

--- a/rebrand/linked-mem-store/src/models.ts
+++ b/rebrand/linked-mem-store/src/models.ts
@@ -1,0 +1,3254 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+import {
+  DefaultGraph as TFDefaultGraph,
+  Literal as ILiteral,
+  NamedNode as INamedNode,
+  Term,
+} from 'rdflib/lib/tf-types.js';
+import {DefaultGraphTermType,TermType} from 'rdflib/lib/types.js';
+import {defaultGraphURI} from 'rdflib/lib/utils/default-graph-uri.js';
+
+import {QuadSet} from './collections/QuadSet.js';
+import {CoreMap} from './collections/CoreMap.js';
+import {QuadMap} from './collections/QuadMap.js';
+import {QuadArray} from './collections/QuadArray.js';
+import {NodeSet} from './collections/NodeSet.js';
+
+import {ICoreIterable} from './interfaces/ICoreIterable.js';
+import {IShape} from './interfaces/IShape.js';
+import {IGraphObject} from './interfaces/IGraphObject.js';
+
+import {NodeValuesSet} from './collections/NodeValuesSet.js';
+import {BatchedEventEmitter,eventBatcher} from './events/EventBatcher.js';
+import {EventEmitter} from './events/EventEmitter.js';
+import {NodeMap} from './collections/NodeMap.js';
+import {NodeURIMappings} from './collections/NodeURIMappings.js';
+import {CoreSet} from './collections/CoreSet.js';
+import {Prefix} from './utils/Prefix.js';
+
+export abstract class Node extends EventEmitter {
+  /** The type of node */
+  termType!: TermType;
+
+  constructor(protected _value: string) {
+    super();
+  }
+
+  get value(): string {
+    return this._value;
+  }
+
+  set value(val: string) {
+    this._value = val;
+  }
+
+  /**
+   * Create an instance of the given class (or one of its subclasses) as a presentation of this node.
+   * NOTE: this node MUST have the static.type of the given class as its rdf:type property
+   * @param type - a class that extends Shape and thus who's instances represent a node as an instance of one specific type.
+   */
+  getAs<T extends IShape>(type: {new (): T; getOf(node: Node): T}): T {
+    return type.getOf(this);
+  }
+
+  /**
+   * Create an instance of the given class as a presentation of this node.
+   * Other than getAs this 'strict' message will ONLY return an exact instance of the given class, not one of its subclasses
+   * rdf.type properties of the node are IGNORED. This method can therefore also come in handy in circumstances when you don't have the node it's rdf.type properties at hand.
+   * Do not misuse this method though, the main use case is if you don't want to allow any subclass instances. If that's not neccecarily the case and it would make also sense to have the properties loaded, make sure to load them and use getAs.
+   * OR use getAsAsync automatically ensures the data of the node is fully loaded before creating an instance.
+   * @param type - a class that extends Shape and thus who's instances represent a node as an instance of one specific type.
+   */
+  getStrictlyAs<T extends IShape>(type: {
+    new (): T;
+    getStrictlyOf(node: Node): T;
+  }): T {
+    return type.getStrictlyOf(this);
+  }
+
+  /**
+   * Compares whether the two nodes are equal
+   * @param other The other node
+   */
+  equals(other: Term): boolean {
+    if (!other) {
+      return false;
+    }
+    return this.termType === other.termType && this.value === other.value;
+  }
+
+  set(property: NamedNode, value: Node): boolean {
+    return false;
+  }
+
+  setValue(property: NamedNode, value: string) {
+    return false;
+  }
+
+  has(property: NamedNode, value: Node): boolean {
+    return false;
+  }
+
+  hasValue(property: NamedNode, value: string): boolean {
+    return false;
+  }
+
+  hasExplicit(property: NamedNode, value: Node): boolean {
+    return false;
+  }
+
+  hasExact(property: NamedNode, value: Node): boolean {
+    return false;
+  }
+
+  hasProperty(property: NamedNode): boolean {
+    return false;
+  }
+
+  hasInverseProperty(property: NamedNode): boolean {
+    return false;
+  }
+
+  hasInverse(property: NamedNode, value: Node): boolean {
+    return false;
+  }
+
+  mset(property: NamedNode, values: Iterable<Node>): boolean {
+    return false;
+  }
+
+  getProperties(includeFromIncomingArcs: boolean = false): NodeSet<NamedNode> {
+    return new NodeSet<NamedNode>();
+  }
+
+  getInverseProperties() {
+    return new NodeSet<NamedNode>();
+  }
+
+  getOne(property: NamedNode): Node | undefined {
+    return undefined;
+  }
+
+  getAll(property: NamedNode): NodeValuesSet {
+    return new NodeValuesSet(this, property);
+  }
+
+  getValue(property?: NamedNode): string {
+    return undefined;
+  }
+
+  getDeep(
+    property: NamedNode,
+    maxDepth: number = -1,
+    partialResult: NodeSet = new NodeSet(),
+  ): NodeSet {
+    return partialResult;
+  }
+
+  getOneInverse(property: NamedNode): NamedNode | undefined {
+    return undefined;
+  }
+
+  getOneWhere(
+    property: NamedNode,
+    filterProperty: NamedNode,
+    filterValue: Node,
+  ): undefined {
+    return undefined;
+  }
+
+  getOneWhereEquivalent(
+    property: NamedNode,
+    filterProperty: NamedNode,
+    filterValue: Node,
+    caseSensitive?: boolean,
+  ): undefined {
+    return undefined;
+  }
+
+  getAllExplicit(property: NamedNode): NodeSet {
+    return undefined;
+  }
+
+  getAllInverse(property: NamedNode): NodeSet<NamedNode> | undefined {
+    return undefined;
+  }
+
+  getMultiple(properties: ICoreIterable<NamedNode>): NodeSet {
+    return new NodeSet();
+  }
+
+  hasPath(properties: NamedNode[]): boolean {
+    return false;
+  }
+
+  hasPathTo(properties: NamedNode[], value?: Node): boolean {
+    return false;
+  }
+
+  hasPathToSomeInSet(
+    properties: NamedNode[],
+    endPoints?: ICoreIterable<Node>,
+  ): boolean {
+    return false;
+  }
+
+  getOneFromPath(...properties: NamedNode[]): Node | undefined {
+    return undefined;
+  }
+
+  getAllFromPath(...properties: NamedNode[]): NodeSet {
+    return new NodeSet();
+  }
+
+  getQuads(property: NamedNode, value?: Node): QuadSet {
+    return new QuadSet();
+  }
+
+  getInverseQuad(property: NamedNode, subject: NamedNode): Quad | undefined {
+    return undefined;
+  }
+
+  getInverseQuads(property: NamedNode): QuadSet {
+    return new QuadSet();
+  }
+
+  getAllInverseQuads(includeImplicit?: boolean): QuadArray {
+    return new QuadArray();
+  }
+
+  getAllQuads(
+    includeAsObject: boolean = false,
+    includeImplicit: boolean = false,
+  ): QuadArray {
+    return null;
+  }
+
+  overwrite(property: NamedNode, value: any): boolean {
+    return false;
+  }
+
+  moverwrite(property: NamedNode, value: any): boolean {
+    return false;
+  }
+
+  unset(property: NamedNode, value: Node): boolean {
+    return false;
+  }
+
+  unsetAll(property: NamedNode): boolean {
+    return false;
+  }
+
+  isLoaded(includingIncomingProperties?: boolean): boolean {
+    return false;
+  }
+
+  promiseLoaded(loadInverseProperties?: boolean): Promise<boolean> {
+    return null;
+  }
+
+  getMultipleInverse(properties: ICoreIterable<NamedNode>): NodeSet {
+    return new NodeSet();
+  }
+
+  /**
+   * @internal
+   * @param quad
+   */
+  unregisterInverseProperty(
+    quad: Quad,
+    alteration?: boolean,
+    emitEvents?: boolean,
+  ): void {}
+
+  /**
+   * registers the use of a quad. Since a quad can only be used in 1 quad
+   * this method makes a clone of the Literal if it's used a second time,
+   * and returns that new Literal so it will be used by the quad
+   * @internal
+   * @param quad
+   */
+  registerInverseProperty(
+    quad: Quad,
+    alteration?: boolean,
+    emitEvents?: boolean,
+  ): Node {
+    return null;
+  }
+
+  clone(): Node {
+    return null;
+  }
+
+  print() {
+    return '';
+  }
+}
+
+/**
+ * A Named Node in the graph is a node that has outgoing edges to other nodes.
+ *
+ * In RDF specifications, a Named Node is a URI Node.
+ * You can manage this by setting and getting 'properties' of this node, which will reflect in which nodes this node is connected with.
+ * A Named Node is one of the two types of nodes in a graph in the semantic web / RDF.
+ * The other one being Literal
+ * @see https://www.w3.org/TR/rdf-concepts/#section-Graph-URIref
+ *
+ * @example
+ *
+ * Use NamedNode.getOrCreate() if you have a URI
+ * Use NamedNode.create() to create a new NamedNode without specifying a URI
+ * Do NOT use the constructor
+ *
+ * ```
+ * let node = NamedNode.create();
+ * let node = NamedNode.getOrCreate("http://url.of.some/node")
+ * ```
+ */
+export class NamedNode
+  extends Node
+  implements IGraphObject, BatchedEventEmitter, INamedNode
+{
+  /**
+   * The base of temporary URI's
+   * @internal
+   */
+  public static TEMP_URI_BASE: string = 'lin://tmp/';
+  /**
+   * Emitter used by the class itself by static methods emitting events.
+   * Anyone wanting to listen to that should therefore add a listener with NamedNode.emitter.on(...)
+   * @internal
+   */
+  static emitter = new EventEmitter();
+  /**
+   * event emitted when nodes need to be stored
+   * @internal
+   */
+  static STORE_NODES: string = 'STORE_NODES';
+  /**
+   * Event emitted when previous values have been overwritten (for example with update or moverwrite)
+   * NOTE: Locally we may not know all the properties, but the intend of update / moverwrite is to overwrite ANY existing properties. So event handlers listening to this event should clear any previous property values they can find.
+   * @internal
+   */
+  static CLEARED_PROPERTIES: string = 'CLEARED_PROPERTIES';
+  /**
+   * event emitted when nodes need to be removed
+   * @internal
+   */
+  static REMOVE_NODES: string = 'REMOVE_NODES';
+  /**
+   * event emitted when the URI of a node has been updated
+   */
+  static URI_UPDATED: string = 'URI_UPDATED';
+  /**
+   * event emitted when nodes need to be loaded
+   * @internal
+   */
+  static LOAD_NODES: string = 'LOAD_NODES';
+  /**
+   * event emitted by a single node when its properties have changed
+   * @internal
+   */
+  static PROPERTY_CHANGED: string = 'PROPERTY_CHANGED';
+  /**
+   * event emitted by a single node when its properties have been altered
+   * NOTE: we use 'altered' for changes made by user interaction vs 'changed' for changes that
+   * could for example be due to new data being loaded
+   * @internal
+   */
+  static PROPERTY_ALTERED: string = 'PROPERTY_ALTERED';
+  /**
+   * event emitted by a single node when its inverse properties have been changed
+   * @internal
+   */
+  static INVERSE_PROPERTY_CHANGED: string = 'INVERSE_PROPERTY_CHANGED';
+
+  //### event types ###
+  /**
+   * event emitted by a single node when its inverse properties have been altered
+   * NOTE: we use 'altered' for changes made by user interaction vs 'changed' for changes that
+   * could for example be due to new data being loaded
+   * @internal
+   */
+  static INVERSE_PROPERTY_ALTERED: string = 'INVERSE_PROPERTY_ALTERED';
+  /**
+   * event emitted by a single node when its used or not used anymore as a predicate
+   * @internal
+   */
+  static AS_PREDICATE_CHANGED: string = 'AS_PREDICATE_CHANGED';
+  /**
+   * event emitted by a single node when its used or not used anymore as a predicate due to user requested alterations
+   * @internal
+   */
+  static AS_PREDICATE_ALTERED: string = 'AS_PREDICATE_ALTERED';
+  /**
+   * event emitted by a single node when it's been removed
+   */
+  static NODE_REMOVED: string = 'NODE_REMOVED';
+  private static namedNodes: NodeMap<NamedNode> = new NodeMap();
+  private static tempCounter: number = 0;
+  private static nodesToSave: NodeSet<NamedNode> = new NodeSet();
+  private static nodesToLoad: NodeSet<NamedNode> = new NodeSet();
+  private static nodesToLoadFully: NodeSet<NamedNode> = new NodeSet();
+  private static nodesToRemove: CoreSet<[NamedNode, QuadArray]> = new CoreSet();
+  private static nodesURIUpdated: CoreMap<NamedNode, [string, string]> =
+    new CoreMap();
+  private static clearedProperties: CoreMap<
+    NamedNode,
+    [NamedNode, QuadArray][]
+  > = new CoreMap();
+  /**
+   * map of QuadMaps indexed by property (where this node occurs as subject)
+   * NOTE: 'properties' serves only to increase lookup speed but also costs memory
+   * since reverse lookup (where this node occurs as object) will be much less frequent
+   * the inverse of 'properties' is not kept, so all results for reverse lookup will be created from 'asObject'
+   * @internal
+   */
+  properties: CoreMap<NamedNode, NodeValuesSet> = new CoreMap<
+    NamedNode,
+    NodeValuesSet
+  >();
+  // private static termType: string = 'NamedNode';
+  termType: any = 'NamedNode';
+  /**
+   * map of QuadMaps indexed by property where this node occurs as subject
+   * NOTE: we use QuadMap here because in ES5 a quadMap is much faster than a quadSet, because we can check by key with uri directly if the quad exists instead of having to look in an array with indexOf (ES5 does not support objects as keys)
+   * @internal
+   */
+  private asSubject: Map<NamedNode, QuadMap> = new Map<NamedNode, QuadMap>();
+  /**
+   * map of QuadMaps indexed by property where this node occurs as object
+   * @internal
+   */
+  private asObject: Map<NamedNode, QuadMap>; // = new Map<NamedNode,QuadMap>();
+
+  //keeping track of changes to be emitted in one batched event
+  /**
+   * array of Quads in which this node occurs as predicate
+   * @internal
+   */
+  // private asPredicate: QuadArray;
+  //NOTE: the quad sets in these maps will contain both newly ADDED and REMOVED quads
+  private changedProperties: CoreMap<NamedNode, QuadSet>;
+  private alteredProperties: CoreMap<NamedNode, QuadSet>;
+  private changedInverseProperties: CoreMap<NamedNode, QuadSet>;
+  private alteredInverseProperties: CoreMap<NamedNode, QuadSet>;
+  // private changedAsPredicate: QuadArray;
+  // private alteredAsPredicate: QuadArray;
+  //keep track of promises so that we only do loading/removing/saving once
+  private savePromise: {
+    promise: Promise<any>;
+    resolve: any;
+    reject: any;
+    done?: boolean;
+  };
+  private removePromise: {promise: Promise<any>; resolve: any; reject: any};
+
+  /**
+   * WARNING: Do not directly create a Node, instead use NamedNode.getOrCreate(uri)
+   * This ensures the same node is used for the same uri system wide
+   * @param uri - the URI (more generic form of a URL) of the NamedNode
+   * @param _isTemporaryNode - set to true if this node is only temporarily available in the local environment
+   */
+  constructor(
+    uri: string = '',
+    private _isTemporaryNode: boolean = false,
+  ) {
+    super(uri);
+    if (this._isTemporaryNode) {
+      //created locally, so we know everything about it there is to know
+      // this.allPropertiesLoaded = {promise: Promise.resolve(this), done: true};
+    }
+  }
+
+  private _isStoring: {promise?; resolve?; reject?};
+
+  get isStoring(): boolean {
+    return this._isStoring && true;
+  }
+
+  set isStoring(storing: boolean) {
+    //when storing
+    if (storing) {
+      //create a deferred promise and store it as _isStoring
+      this._isStoring = {};
+      this._isStoring.promise = new Promise((resolve, reject) => {
+        this._isStoring.resolve = resolve;
+        this._isStoring.reject = reject;
+      });
+    } else {
+      //when done storing, resolve the promise
+      this._isStoring.resolve();
+      delete this._isStoring;
+    }
+  }
+
+  /**
+   * JSLib.js documentation states: "Alias for value, favored by Tim" ... LINCD author René agrees with Tim
+   * @see https://github.com/linkeddata/rdflib.js/blob/bbf456390afe7743020e0c8c4db20b10cfb808c7/src/named-node.ts#L88
+   */
+  get uri(): string {
+    return this._value;
+  }
+
+  set uri(uri: string) {
+    this.value = uri;
+  }
+
+  /**
+   * Returns true if this node has a temporary URI and only exists in the local environment.
+   * e.g. this is usually true if you create a new NamedNode without having specified a URI yet
+   */
+  get isTemporaryNode(): boolean {
+    return this._isTemporaryNode;
+  }
+
+  set isTemporaryNode(val: boolean) {
+    this._isTemporaryNode = val;
+  }
+
+  get value(): string {
+    return this._value;
+  }
+
+  set value(newUri: string) {
+    if (NamedNode.namedNodes.has(newUri)) {
+      throw new Error(
+        'Cannot update URI. A node with this URI already exists: ' +
+          newUri +
+          '. You tried to update the URI of ' +
+          this._value,
+      );
+    }
+
+    var oldUri = this._value;
+    NamedNode.namedNodes.delete(this._value);
+    this._value = newUri;
+    NamedNode.namedNodes.set(this._value, this);
+
+    // //if this node had a temporary URI
+    // if (this._isTemporaryNode) {
+    // 	//it now has an explicit URI, so it's no longer temporary
+    // 	this._isTemporaryNode = false;
+    // }
+
+    this.emit(NamedNode.URI_UPDATED, this, oldUri, newUri);
+
+    eventBatcher.register(NamedNode);
+    NamedNode.nodesURIUpdated.set(this, [oldUri, newUri]);
+  }
+
+  /**
+   * Emits the batched (property) events of the NamedNode CLASS (meaning events that relate to all nodes)
+   * Used internally by the framework to batch and emit change events
+   * @internal
+   */
+  static emitBatchedEvents(resolve, reject) {
+    if (this.nodesToRemove.size) {
+      this.emitter.emit(NamedNode.REMOVE_NODES, this.nodesToRemove);
+      this.nodesToRemove = new CoreSet<[NamedNode, QuadArray]>();
+    }
+
+    if (this.nodesToSave.size) {
+      this.emitter.emit(NamedNode.STORE_NODES, this.nodesToSave);
+      this.nodesToSave = new NodeSet<NamedNode>();
+    }
+
+    if (this.nodesToLoad.size || this.nodesToLoadFully.size) {
+      this.emitter.emit(
+        NamedNode.LOAD_NODES,
+        this.nodesToLoad,
+        this.nodesToLoadFully,
+      );
+      this.nodesToLoad = new NodeSet<NamedNode>();
+      this.nodesToLoadFully = new NodeSet<NamedNode>();
+    }
+
+    if (this.nodesURIUpdated.size) {
+      this.emitter.emit(NamedNode.URI_UPDATED, this.nodesURIUpdated);
+      this.nodesURIUpdated = new CoreMap();
+    }
+
+    if (this.clearedProperties.size) {
+      this.emitter.emit(NamedNode.CLEARED_PROPERTIES, this.clearedProperties);
+      this.clearedProperties = new CoreMap();
+    }
+  }
+
+  /**
+   * Returns true if this node has any batched events waiting to be emitted
+   * Used internally by the framework to batch and emit change events
+   * @internal
+   */
+  static hasBatchedEvents() {
+    return (
+      this.nodesToRemove.size > 0 ||
+      this.nodesToSave.size > 0 ||
+      this.nodesToLoad.size ||
+      this.nodesToLoadFully.size > 0 ||
+      this.nodesURIUpdated.size > 0 ||
+      this.clearedProperties.size > 0
+    );
+  }
+
+  /**
+   * Converts the string '<http://some.uri>' into a NamedNode
+   * @param uriString the string representation of a NamedNode, consisting of its URI surrounded by brackets: '<' URI '>'
+   */
+  static fromString(uriString: string): NamedNode {
+    var firstChar = uriString.substr(0, 1);
+    if (firstChar == '<') {
+      return this.getOrCreate(uriString.substr(1, uriString.length - 2));
+    } else {
+      throw new Error(
+        'fromString expects a URI wrapped in brackets, like <http://www.example.com>',
+      );
+    }
+  }
+
+  /**
+   * Resets the map of nodes that is known in this local environment
+   * Mostly used for test functionality
+   */
+  static reset() {
+    this.tempCounter = 0;
+    this.namedNodes = new NodeMap();
+  }
+
+  /**
+   * Create a new local NamedNode. A temporary URI will be generated for its URI.
+   * This node will not exist in the graph database (persistent storage) until you call `node.save()`
+   * Until saved, `node.isTemporaryNode()` will return true.
+   */
+  static create(): NamedNode {
+    let tmpURI = this.createNewTempUri();
+    while (this.getNamedNode(tmpURI)) {
+      this.tempCounter++;
+      tmpURI = this.createNewTempUri();
+    }
+    return this._create(tmpURI, true);
+  }
+
+  /**
+   * Registers a NamedNode to the locally known list of nodes
+   * @internal
+   * @param node
+   */
+  static register(node: NamedNode) {
+    if (this.namedNodes.has(node.uri)) {
+      throw new Error(
+        'A node with this URI already exists: "' +
+          node.uri +
+          '". You should probably use NamedNode.getOrCreate instead of NamedNode.create (' +
+          node.uri +
+          ')',
+      );
+    }
+    this.namedNodes.set(node.uri, node);
+  }
+
+  /**
+   * Unregisters a NamedNode from the locally known list of nodes
+   * @internal
+   * @param node
+   */
+  static unregister(node: NamedNode) {
+    if (!this.namedNodes.has(node.uri)) {
+      throw new Error(
+        'This node has already been removed from the registry: ' + node.uri,
+      );
+    }
+    this.namedNodes.delete(node.uri);
+  }
+
+  /**
+   * Returns a map of all locally known nodes.
+   * The map will have URI's as keys and NamedNodes as values
+   * @param node
+   */
+  static getAllNamedNodes(): NodeMap<NamedNode> {
+    return this.namedNodes;
+  }
+
+  /**
+   * Returns a map of all locally known nodes.
+   * The map will have URI's as keys and NamedNodes as values
+   * @param node
+   */
+  static createNewTempUri() {
+    return this.TEMP_URI_BASE + this.tempCounter++; //+'/';+Date.now()+Math.random();
+  }
+
+  static getCounter(): number {
+    return this.tempCounter;
+  }
+
+  /**
+   * ##########################################################################
+   * ############# PUBLIC METHODS FOR REGULAR USE #############
+   * ##########################################################################
+   */
+
+  /**
+   * The proper way to obtain a node from a URI.
+   * If requested before, this returns the existing NamedNode for the given URI.
+   * Or, if this is the first request for this URI, it creates a new NamedNode first, and returns that
+   * Using this method over `new NamedNode()` makes sure all nodes are registered, and no duplicates will exist.
+   * `new NamedNode()` should therefore never be used.
+   * @param uri
+   */
+  static getOrCreate(uri: string, isTemporaryNode: boolean = false) {
+    return this.getNamedNode(uri) || this._create(uri, isTemporaryNode);
+  }
+
+  /**
+   * Returns the NamedNode with the given URI, IF it exists.
+   * DOES NOT create a new NamedNode if it didn't exist yet, instead it returns undefined.
+   * You can therefore use this method to see if a NamedNode already exists locally.
+   * Use `getOrCreate()` if you want to simply get a NamedNode for a certain URI
+   * @param uri
+   */
+  static getNamedNode(uri: string): NamedNode | undefined {
+    return this.namedNodes.get(uri);
+  }
+
+  static emitClearedProperty(node: NamedNode, property: NamedNode) {
+    //if not a local node we will emit events for storage controllers to be picked up
+    if (!node.isTemporaryNode) {
+      //regardless of how many values are known 'locally', we want to emit this event so that the source of data can eventually properly clear all values
+      if (!NamedNode.clearedProperties.has(node)) {
+        NamedNode.clearedProperties.set(node, []);
+        eventBatcher.register(NamedNode);
+      }
+      //we save the property that was cleared AND the quads that were cleared
+      NamedNode.clearedProperties
+        .get(node)
+        .push([
+          property,
+          node.asSubject.has(property)
+            ? new QuadArray(...node.asSubject.get(property).getQuadSet())
+            : null,
+        ]);
+    }
+  }
+
+  private static _create(uri: string, isLocalNode: boolean = false): NamedNode {
+    var node = new NamedNode(uri, isLocalNode);
+    this.register(node);
+    return node;
+  }
+
+  /**
+   * Used by Quads to signal their subject about a new property
+   * @internal
+   * @param quad
+   * @param alteration
+   * @param emitEvents
+   */
+  registerProperty(
+    quad: Quad,
+    alteration: boolean = false,
+    emitEvents: boolean = true,
+  ) {
+    var predicate: NamedNode = quad.predicate;
+    //first make sure we have a QuadMap value for key=predicate
+    if (!this.asSubject.has(predicate)) {
+      this.asSubject.set(predicate, new QuadMap());
+      this.properties.set(predicate, new NodeValuesSet(this, predicate));
+    }
+
+    //Add the quad to the QuadMap (see implementation for more details)
+    let quadMap = this.asSubject.get(predicate);
+
+    //make sure we have a QuadSet ready for the object of this quad
+    quadMap.__set(quad.object, quad);
+
+    //Now for the property index (which gives direct access to the object values of a certain predicate)
+    //Because multiple graphs can hold the same subj-pred-obj triple, we want to avoid adding literal values
+    //that have the exact same literal value, so we need to test for equality here before adding it
+    if (
+      !this.properties
+        .get(predicate)
+        .some((object) => object.equals(quad.object))
+    ) {
+      this.properties.get(predicate).__add(quad.object);
+    }
+
+    //add this quad to the map of events to send on the next tick
+    if (emitEvents) {
+      if (!this.changedProperties) this.changedProperties = new CoreMap();
+      if (alteration && !this.alteredProperties)
+        this.alteredProperties = new CoreMap();
+      //register this change as alteration (user input) or as normal (automatic, data based) property change
+      this.registerPropertyChange(
+        quad,
+        alteration
+          ? [this.changedProperties, this.alteredProperties]
+          : [this.changedProperties],
+      );
+    }
+  }
+
+  /**
+   * Inverse property can be thought of as "this node is the value (object) of another nodes' property"
+   * This method is used by the class Quad to communicate its existence to the quads object
+   * @internal
+   * @param quad
+   * @param alteration
+   * @param emitEvents
+   */
+  registerInverseProperty(
+    quad: Quad,
+    alteration: boolean = false,
+    emitEvents: boolean = true,
+  ): Node {
+    //asObject is not always initialised - to save some memory on nodes without incoming properties (only used as subject)
+    if (!this.asObject) {
+      this.asObject = new CoreMap<NamedNode, QuadMap>();
+    }
+    var index: NamedNode = quad.predicate;
+    if (!this.asObject.has(index)) {
+      this.asObject.set(index, new QuadMap());
+    }
+    this.asObject.get(index).__set(quad.subject, quad);
+
+    //add this quad to the map of events to send on the next tick
+    if (emitEvents) {
+      if (!this.changedInverseProperties)
+        this.changedInverseProperties = new CoreMap();
+      if (alteration && !this.alteredInverseProperties)
+        this.alteredInverseProperties = new CoreMap();
+      this.registerPropertyChange(
+        quad,
+        alteration
+          ? [this.changedInverseProperties, this.alteredInverseProperties]
+          : [this.changedInverseProperties],
+      );
+    }
+
+    //need to return this, see Literal
+    return this;
+  }
+
+  /**
+   * Called when this node occurs as predicate in a quad
+   * @internal
+   */
+  // registerAsPredicate(
+  //   quad: Quad,
+  //   alteration: boolean = false,
+  //   emitEvents: boolean = true,
+  // ) {
+  //   //asPredicate is not always initialised because only properties can occur as predicate
+  //   if (!this.asPredicate) {
+  //     this.asPredicate = new QuadArray();
+  //   }
+  //   this.asPredicate.push(quad);
+  //
+  //   if (emitEvents) {
+  //     this.registerPredicateChange(quad, alteration);
+  //   }
+  // }
+
+  /**
+   * This method is used by the class Quad to communicate with its nodes
+   * @internal
+   * @param quad
+   * @param alteration
+   */
+  registerValueChange(quad: Quad, alteration: boolean = false) {
+    if (!this.changedProperties) this.changedProperties = new CoreMap();
+    if (alteration) {
+      if (!this.alteredProperties) this.alteredProperties = new CoreMap();
+    }
+    this.registerPropertyChange(
+      quad,
+      alteration
+        ? [this.changedProperties, this.alteredProperties]
+        : [this.changedProperties],
+    );
+  }
+
+  /**
+   * This method is used by the class Quad to communicate with its nodes
+   * @internal
+   */
+  unregisterProperty(
+    quad: Quad,
+    alteration: boolean = false,
+    emitEvents: boolean = true,
+  ) {
+    var predicate: NamedNode = quad.predicate;
+
+    //start by looking through the QuadMap (it is more complete than the quick & easy properties index, as it accounts for multiple quads per object value in different graphs)
+    var quadMap: QuadMap = this.asSubject.get(predicate);
+    if (quadMap) {
+      let valueQuads = quadMap.get(quad.object);
+      if (!valueQuads) return;
+      valueQuads.delete(quad);
+      //if we no longer hold any quads for this object
+      if (valueQuads.size == 0) {
+        //remove the key
+        quadMap.__delete(quad.object);
+
+        //for this.properties we just keep ONE value for identical literals (in case multiple graphs hold the same subject-pred-obj triple)
+        //so here we check if any other object that is still registered equals the current object
+        if (![...quadMap.keys()].some((object) => quad.object.equals(object))) {
+          //if that's not the case, then also remove this object from the propertySet index (the index should exist)
+          //Note: in some cases, for example when a quad moved between graphs, the object registered here as property value might not be the same as the as the object of the quad that is still registered,
+          // therefor we also check & remove equivalent values in case regular removal didnt work
+          //TODO: we could improve this by making sure that this.properties stays up to date with the actual quads
+          this.properties.get(predicate).__delete(quad.object) ||
+            this.properties
+              .get(predicate)
+              .__delete(
+                this.properties
+                  .get(predicate)
+                  .find((object) => object.equals(quad.object)),
+              );
+        }
+
+        //if we now also no longer hold any values for this predicate
+        //NOTE: this was turned off because NodeValuesSets are reused, recreating a new one when a new value
+        // is added then does not add the value to the old one.
+        // if (quadMap.size === 0) {
+        //   //delete both indices for this predicate
+        //   this.asSubject.delete(predicate);
+        //   this.properties.delete(predicate);
+        // }
+      }
+    }
+
+    //NOTE: also when removing property values (therefore unregistering the property), we add the removed quad to the SAME list of changed properties
+    //event listeners will have to filter out which quad was added or removed
+    if (emitEvents) {
+      if (!this.changedProperties) this.changedProperties = new CoreMap();
+      if (alteration && !this.alteredProperties)
+        this.alteredProperties = new CoreMap();
+
+      this.registerPropertyChange(
+        quad,
+        alteration
+          ? [this.changedProperties, this.alteredProperties]
+          : [this.changedProperties],
+      );
+    }
+  }
+
+  /**
+   * This method is used by the class Quad to communicate with its nodes
+   * @internal
+   */
+  // unregisterAsPredicate(
+  //   quad: Quad,
+  //   alteration: boolean = false,
+  //   emitEvents: boolean = true,
+  // ) {
+  //   this.asPredicate.splice(this.asPredicate.indexOf(quad), 1);
+  //
+  //   if (emitEvents) {
+  //     this.registerPredicateChange(quad, alteration);
+  //   }
+  // }
+  //
+  // /**
+  //  * Returns a list of quads in which this node is now used as predicate
+  //  * BEFORE these changes are sent as events in the normal event flow
+  //  * Currently used by Reasoner to allow for immediate application of reasoning
+  //  */
+  // getPendingPredicateChanges(): QuadArray {
+  //   return this.changedAsPredicate;
+  // }
+
+  /**
+   * This method is used by the class Quad to communicate with its nodes
+   * @internal
+   */
+  unregisterInverseProperty(
+    quad: Quad,
+    alteration: boolean = false,
+    emitEvents: boolean = true,
+  ) {
+    //start by looking through the QuadMap (it is more complete than the quick & easy properties index, as it accounts for identical sub-pred-obj triples that occur in different graphs)
+    //here we get a map of all the quads for the given predicate, grouped by subject (each map contains identical triples, but with different graphs)
+    var quadMap: QuadMap = this.asObject.get(quad.predicate);
+    if (quadMap) {
+      let quadSet = quadMap.get(quad.subject);
+      if (!quadSet) return;
+      //remove this quad
+      quadSet.delete(quad);
+      //if we no longer hold any quads for this subject
+      if (quadSet.size === 0) {
+        quadMap.__delete(quad.subject);
+      }
+      if (quadMap.size == 0) {
+        this.asObject.delete(quad.predicate);
+      }
+    }
+
+    //also when removing the property do wee add the removed quad to the list of changed properties
+    //event listeners will have to filter out which quad was added or removed
+    if (emitEvents) {
+      if (!this.changedInverseProperties)
+        this.changedInverseProperties = new CoreMap();
+      if (alteration && !this.alteredInverseProperties)
+        this.alteredInverseProperties = new CoreMap();
+
+      this.registerPropertyChange(
+        quad,
+        alteration
+          ? [this.changedInverseProperties, this.alteredInverseProperties]
+          : [this.changedInverseProperties],
+      );
+    }
+  }
+
+  /**
+   * Returns a list of quads in which this node is now used as object
+   * BEFORE these changes are sent as events in the normal event flow
+   * Currently used by Reasoner to allow for immediate application of reasoning
+   */
+  getPendingInverseChanges(property: NamedNode): QuadSet {
+    return this.changedInverseProperties
+      ? this.changedInverseProperties.get(property)
+      : new QuadSet();
+  }
+
+  /**
+   * Returns a list of quads in which this node is now used as subject
+   * BEFORE these changes are sent as events in the normal event flow
+   * Currently used by Reasoner to allow for immediate application of reasoning
+   */
+  getPendingChanges(property: NamedNode): QuadSet {
+    return this.changedProperties.get(property);
+  }
+
+  /**
+   * Set the a single property value
+   * Creates a single connection between two nodes in the graph: from this node, to the node given as value, with the property as the connecting 'edge' between them
+   * @param property - a NamedNode with rdf:type rdf:Property, the edge in the graph, the predicate of a quad
+   * @param value - the node that this new graph-edge points to. The object of the quad to be created.
+   */
+  set(property: NamedNode, value: Node): boolean {
+    if (!value) {
+      throw Error('No value provided to set!');
+    }
+    //if there is already a quad with exactly this prop-value pair
+    if (this.has(property, value)) {
+      //make all quads with this pair explicit if they were not yet
+      this.getQuads(property, value).makeExplicit();
+      //yet return false because nothing was changes in the propreties
+      return false;
+    }
+    //if this pair didn't exist yet, create a new quad (the graph is undefined for now, Storage will pick this up and place it in the right graph)
+    //note that the sixth parameter is true, this indicates that this is an alteration (as in new data that triggers change events instead of a quad created for already existing data)
+    new Quad(this, property, value, undefined, false, true);
+    return true;
+  }
+
+  /**
+   * Same as set() except this method allows you to pass a string as value and converts it to a Literal for you
+   * @param property
+   * @param value
+   */
+  setValue(property: NamedNode, value: string) {
+    return this.set(property, new Literal(value));
+  }
+
+  /**
+   * Set multiple values at once for a single property.
+   * You can use this for example to state that this node (a person) has a 'hasFriend' connection to multiple people (friends) in 1 statement
+   * @param property - a NamedNode with rdf:type rdf:Property, the edge in the graph, the predicate of a quad
+   * @param values - an array or set of nodes. Can be NamedNodes or Literals
+   */
+  mset(property: NamedNode, values: ICoreIterable<Node>): boolean {
+    //if(save) dacore.system.storageQueueStart(this);
+    var res = false;
+    for (var value of values) {
+      res = this.set(property, value) || res;
+    }
+    return res;
+  }
+
+  /**
+   * Returns true if this node has the given value as the value of the given property
+   * NOTE: returns true when a literal node is provided that is EQUIVALENT to any of the values that this node has for this property (whilst not neccecarilly being the exact same object in memory)
+   * See also: Literal.equals
+   * @param property - a NamedNode with rdf:type rdf:Property, the edge in the graph, the predicate of a quad
+   * @param value - a single node. Can be a NamedNode or Literal
+   */
+  has(property: NamedNode, value: Node): boolean {
+    if (!value) {
+      throw new Error(
+        'No value provided to NamedNode.has(). Did you mean `hasProperty`?',
+      );
+    }
+    var properties = this.properties.get(property);
+    return (
+      properties &&
+      (properties.has(value) ||
+        properties.some((object) => object.equals(value)))
+    );
+  }
+
+  /**
+   * Returns true if this node has the given value for the given property in an EXPLICIT quad.
+   * That is, this property-value has been explicitly set, and is NOT generated by the Reasoner.
+   * See the documentation for more information about implicit vs explicit
+   * @param property - a NamedNode with rdf:type rdf:Property, the edge in the graph, the predicate of a quad
+   * @param value - a single node. Can be a NamedNode or Literal
+   */
+  hasExplicit(property: NamedNode, value: Node): boolean {
+    if (!this.asSubject.has(property)) return false;
+    return this.getQuadsByValue(property, value).some((quad) => !quad.implicit);
+  }
+
+  /**
+   * Returns true if this node has ANY explicit quad with the given property
+   * See the documentation for more information about implicit vs explicit
+   * @param property - a NamedNode with rdf:type rdf:Property, the edge in the graph, the predicate of a quad
+   */
+  hasExplicitProperty(property: NamedNode) {
+    if (!this.asSubject.has(property)) return false;
+    return this.getQuads(property).some((quad) => !quad.implicit);
+  }
+
+  /**
+   * Returns true if this node has a Literal as value of the given property who's literal-value (a string) matches the given value
+   * So works the same as `has()` except you can provide a string as value, and will obviously not match any NamedNode values
+   * And unlike has() this method will NOT check for the Literal its datatype. Instead only checking the literal-value
+   * @param property - a NamedNode with rdf:type rdf:Property, the edge in the graph, the predicate of a quad
+   * @param value - the string value we want to check for
+   */
+  hasValue(property: NamedNode, value: string): boolean {
+    var properties = this.properties.get(property);
+    return (
+      properties &&
+      properties.some(
+        (object) => 'value' in object && object['value'] === value,
+      )
+    );
+  }
+
+  /**
+   * Returns true if this node has the given value as the value of the given property with an EXACT match (meaning the same object in memory)
+   * So works the same as has() except for Literals this only returns true if the value of the property is exactly the same object as the given value
+   * UNLIKE `has()` which checks if the literal value, datatype and language tag of two literal nodes are equivalent
+   * @param property - a NamedNode with rdf:type rdf:Property, the edge in the graph, the predicate of a quad
+   * @param value - a single node. Can be a NamedNode or Literal
+   */
+  hasExact(property: NamedNode, value: Node): boolean {
+    var properties = this.properties.get(property);
+    return properties && properties.has(value);
+  }
+
+  /**
+   * Returns true if this node has ANY value set for the given property.
+   * That is, if any quad exists that has this node as the subject and the given property as predicate
+   * @param property - a NamedNode with rdf:type rdf:Property, the edge in the graph, the predicate of a quad
+   */
+  hasProperty(property: NamedNode): boolean {
+    //properties can be empty sets, so we need to check if there are any values in the set
+    return (
+      this.properties.has(property) && this.properties.get(property).size > 0
+    );
+  }
+
+  /**
+   * Returns true if the given end point can be reached by following the given properties in order
+   * Example: hasPathTo([foaf.hasFriend,rdf.type],foaf.Person) will return true if any of the friends of this node (this person in this example) is of the type foaf:Person
+   * @param properties an array of NamedNodes
+   * @param endPoint the node to reach, a Literal or a NamedNode
+   */
+  hasPathTo(properties: NamedNode[], endPoint?: Node): boolean {
+    //we just need to find one matching path, so we do a depth-first algorithm which will be more performant, so:
+    //take first property
+    var property = properties.shift();
+
+    //if more properties left
+    if (properties.length > 0) {
+      var res;
+      //check if any of the values of that property for this node
+      //has a path to the rest of the properties, and if so return the found value
+      for (var value of this.getAll(property)) {
+        if ((res = value.hasPathTo([...properties], endPoint))) {
+          return res;
+        }
+      }
+      return false;
+    } else {
+      //if last property
+      //see if we can reach the value if a value was given
+      //else: see if any value (any path) exists
+      if (endPoint) {
+        return this.has(property, endPoint);
+      } else {
+        return this.hasProperty(property);
+      }
+    }
+  }
+
+  getAs<T extends IShape>(type: {new (): T; getOf(node: Node): T}): T {
+    return type.getOf(this);
+  }
+
+  /**
+   * returns true if ANY of the given end points can be reached by following the given properties in the given order
+   * Example: hasPathTo([foaf.hasFriend,foaf.hasFriend],[mike,jenny]) will return true if this node (person) has a friend that has mike or jenny as a friend
+   * @param properties an array of NamedNodes
+   * @param endPoint the node to reach, a Literal or a NamedNode
+   */
+  hasPathToSomeInSet(
+    properties: NamedNode[],
+    endPoints?: ICoreIterable<Node>,
+  ): boolean {
+    //we just need to find one matching path, so we do a depth-first algorithm which will be more performant, so:
+    //take first property
+    var property = properties.shift();
+
+    //if more properties left
+    if (properties.length > 0) {
+      var res;
+      //check if any of the values of that property for this node
+      //has a path to the rest of the properties, and if so return the found value
+      for (var value of this.getAll(property)) {
+        if ((res = value.hasPathToSomeInSet([...properties], endPoints))) {
+          return res;
+        }
+      }
+      return false;
+    } else {
+      //if last property
+      //see if we can reach the value if a value was given
+      //else: see if any value (any path) exists
+      return endPoints.some((endPoint) => this.has(property, endPoint));
+    }
+  }
+
+  /**
+   * returns true if ANY end point (node) can be reached by following the given properties in order
+   * @param properties an array of NamedNodes
+   */
+  hasPath(properties: NamedNode[]): boolean {
+    //we just need to find one matching path, so we do a depth-first algorithm which will be more performant, so:
+    //take first property
+    var property = properties.shift();
+
+    //if more properties left
+    if (properties.length > 0) {
+      var res;
+      //check if any of the values of that property for this node
+      //has a path to the rest of the properties, and if so return the found value
+      for (var value of this.getAll(property)) {
+        if ((res = value.hasPath([...properties]))) {
+          return res;
+        }
+      }
+      return false;
+    } else {
+      //if last property
+      //see if we can reach the value if a value was given
+      //else: see if any value (any path) exists
+      return this.hasProperty(property);
+    }
+  }
+
+  /**
+   * Returns a set of all the properties this node has.
+   * That is, all unique predicates of quads where this node is the subject
+   * @param includeFromIncomingArcs if true, also includes predicates (properties) of quads where this node is the VALUE of another nodes' property. Default: false
+   */
+  getProperties(includeFromIncomingArcs: boolean = false): NodeSet<NamedNode> {
+    if (includeFromIncomingArcs) {
+      return new NodeSet<NamedNode>(
+        (this.asObject
+          ? [...this.asSubject.keys(), ...this.asObject.keys()]
+          : this.asSubject.keys()) as Iterable<NamedNode>,
+      );
+    } else {
+      return new NodeSet<NamedNode>(this.asSubject.keys());
+    }
+  }
+
+  /**
+   * Returns a set of all the properties used by this node in EXPLICIT facts (quads)
+   * See the documentation for more information about implicit vs explicit facts
+   * @param includeFromIncomingArcs if true, also includes predicates (properties) of quads where this node is the VALUE of another nodes' property. Default: false
+   */
+  getExplicitProperties(
+    includeFromIncomingArcs: boolean = false,
+  ): NodeSet<NamedNode> {
+    return new NodeSet<NamedNode>([
+      ...this.getAllQuads(includeFromIncomingArcs)
+        .filter((t) => !t.implicit)
+        .map((t) => t.predicate),
+    ]);
+  }
+
+  /**
+   * Returns a set of all the properties used by other nodes where this node is the VALUE of that property
+   * For example if this node is Jenny and the following is true: Mike foaf:hasFriend Jenny, calling this method on Jenny will return hasFriend
+   */
+  getInverseProperties() {
+    return this.asObject
+      ? new NodeSet<NamedNode>(this.asObject.keys())
+      : new NodeSet<NamedNode>();
+  }
+
+  /**
+   * If this node has values for the given property, the first value is returned
+   * NOTE: the order of multiple values CANNOT be guaranteed. Therefore use this value if it DOESN'T matter to you which of multiple possible values for this property you'll get OR if you're certain there will be only 1 value.
+   * @param property - a NamedNode with rdf:type rdf:Property, the edge in the graph, the predicate of a quad
+   */
+  getOne(property: NamedNode): Node | undefined {
+    return this.properties.has(property)
+      ? this.properties.get(property).first()
+      : undefined;
+  }
+
+  /**
+   * If this node has EXPLICIT values for the given property, the first value is returned
+   * Same as `getOne()` except only explicit quads / facts are considered
+   * @param property - a NamedNode with rdf:type rdf:Property, the edge in the graph, the predicate of a quad
+   */
+  getOneExplicit(property: NamedNode): Node | undefined {
+    for (let quad of this.getQuads(property)) {
+      if (!quad.implicit) {
+        return quad.object;
+      }
+    }
+  }
+
+  /**
+   * Returns all values this node has for the given property
+   * @param property - a NamedNode with rdf:type rdf:Property, the edge in the graph, the predicate of a quad
+   */
+  getAll(property: NamedNode): NodeValuesSet {
+    //we usually just index all the existing properties
+    //but to have consistent behaviour with PropertyValueSets, when you request a property that has no values
+    //we need to create an index for the empty result set
+    if (!this.properties.has(property)) {
+      this.asSubject.set(property, new QuadMap());
+      this.properties.set(property, new NodeValuesSet(this, property));
+    }
+    return this.properties.get(property);
+    // return this.properties.has(property)
+    // 	? this.properties.get(property)
+    // 	: new PropertyValueSet(this,property);
+  }
+
+  /**
+   * Returns all values this node EXPLICITLY has for the given property
+   * So, same as `getAll()` except only explicit facts are considered.
+   * See the documentation for more information about implicit vs explicit
+   * @param property - a NamedNode with rdf:type rdf:Property, the edge in the graph, the predicate of a quad
+   */
+  getAllExplicit(property): NodeSet {
+    return this.getExplicitQuads(property).getObjects();
+  }
+
+  /**
+   * Returns the literal value of the first Literal value for the given property
+   * Only returns a results in the disired language if specified.
+   * For example if `this rdfs:label "my name" then this.getValue(rdfs.label) will return "my name".
+   * So, works the same as getOne() except it will return the literal (string) value of the first found Literal
+   * NOTE: the order of multiple values CANNOT be guaranteed. Therefore use this value if it DOESN'T matter to you which of multiple possible values for this property you'll get OR if you're certain there will be only one value.
+   * @param property - a NamedNode with rdf:type rdf:Property, the edge in the graph, the predicate of a quad
+   */
+  //NOTE: we have to overload getValue without parameters here to be compatible with Literal
+  getValue(property?: NamedNode, language?: string): string {
+    //going over all property values
+    for (var valueObject of this.getAll(property)) {
+      //see if its a Literal
+      //we do this by checking if value exists in the valueObject.
+      //And we do that like this because we dont want to explicitly import Literal here.
+      //@TODO: Possibly create an interface to avoid this 'hacky' workaround
+      if (
+        valueObject['value'] &&
+        (!language || valueObject['isOfLanguage'](language))
+      ) {
+        return valueObject.value;
+      }
+    }
+  }
+
+  /**
+   * Returns the literal values (strings) of all Literals this this node has a value for the given property
+   * For example if `this rdfs:label "my name" and `this rdfs:label "my other name"  it will return ["my name","my other name"].
+   * So, works the same as getAll() except it will return an array of strings
+   * @param property - a NamedNode with rdf:type rdf:Property, the edge in the graph, the predicate of a quad
+   */
+  getValues(property: NamedNode): string[] {
+    var valueObjects = this.getAll(property);
+    var res = [];
+    valueObjects.forEach((valueObject) => {
+      if ('value' in valueObject) {
+        res.push(valueObject['value']);
+      }
+    });
+    return res;
+  }
+
+  /**
+   * Returns any value (node, node) that is connected to this node with one or more connections of the given property.
+   * For example getDeep(hasFriend) will return all the people that are my friends or friends of friends
+   * @param property - a NamedNode with rdf:type rdf:Property, the edge in the graph, the predicate of a quad
+   * @param maxDepth - the maximum number of connections that resulting nodes are removed from this node. In the example above maxDepth=2 would return only friends and friends of friends
+   */
+  getDeep(property: NamedNode, maxDepth: number = Infinity): NodeSet {
+    var result = new NodeSet();
+    var stack = new NodeSet([this as Node]);
+    while (stack.size > 0 && maxDepth > 0) {
+      var nextLevelStack = new NodeSet();
+      for (let node of stack) {
+        for (var value of node.getAll(property)) {
+          if (!result.has(value)) {
+            result.add(value);
+            nextLevelStack.add(value);
+          }
+        }
+      }
+      stack = nextLevelStack;
+      maxDepth--;
+    }
+    return result;
+  }
+
+  /**
+   * Returns the first found value following the given properties in the given order.
+   * For example: getOneFromPath([hasFriend,hasFather]) would return the first found father out of the set 'fathers of my friends'
+   * @param properties - an array of NamedNodes. Which are nodes with rdf:type rdf:Property, the edges in the graph, the predicates of quads.
+   */
+  getOneFromPath(...properties: NamedNode[]): Node | undefined {
+    //we just need one, so we do a depth-first algorithm which will be more performant, so:
+    //take first property
+    var property = properties.shift();
+
+    //if more properties left
+    if (properties.length > 0) {
+      var res;
+      //check if any of the values of that property for this node
+      //has a path to the rest of the properties, and if so return the found value
+      for (var value of this.getAll(property)) {
+        if ((res = value.getOneFromPath(...properties))) {
+          return res;
+        }
+      }
+    } else {
+      //return the first value possible
+      return this.getOne(property);
+    }
+  }
+
+  /**
+   * Returns all values that can be reached by following the given properties in order.
+   * For example getAllFromPath([hasFriend,hasFather]) will return all fathers of all my (direct) friends
+   * @param properties - an array of NamedNodes. Which are nodes with rdf:type rdf:Property, the edges in the graph, the predicates of quads.
+   */
+  getAllFromPath(...properties: NamedNode[]): NodeSet {
+    //we just need all paths, so we can do a breadth first implementation
+    //take first property
+    var property = properties.shift();
+
+    if (properties.length > 0) {
+      //and ask the whole set of values to return all values of the rest of the path
+      return this.getAll(property).getAllFromPath(...properties);
+    } else {
+      return this.getAll(property);
+    }
+  }
+
+  /**
+   * Same as getDeep() but for inverse properties.
+   * Best understood with an example: if this is a person. this.getInverseDeep(hasChild) would return all this persons ancestors (which had children that eventually had this person as their child)
+   * @param property - a NamedNode with rdf:type rdf:Property, the edge in the graph, the predicate of a quad
+   * @param maxDepth - the maximum number of connections that resulting nodes are removed from this node. In the example above maxDepth=2 would return only the parents and grand parents
+   */
+  getInverseDeep(property: NamedNode, maxDepth: number = Infinity): NodeSet {
+    var result = new NodeSet();
+    var stack = new NodeSet([this as Node]);
+    while (stack.size > 0 && maxDepth > 0) {
+      var nextLevelStack = new NodeSet();
+      for (let node of stack) {
+        for (var value of node.getAllInverse(property)) {
+          if (!result.has(value)) {
+            result.add(value);
+            nextLevelStack.add(value);
+          }
+        }
+      }
+      stack = nextLevelStack;
+      maxDepth--;
+    }
+    return result;
+  }
+
+  /**
+   * Returns true if the given value can be reached with one or more connections of the given property
+   * Example: if this is a person. this.hasDeep(hasFriend,Mike) returns true if this person has Mike as a friend, or if any this persons friends or friends of friends have Mike as a friend.
+   * @param property - a NamedNode with rdf:type rdf:Property, the edge in the graph, the predicate of a quad
+   * @param maxDepth - the maximum number of connections that resulting nodes are removed from this node. In the example above maxDepth=2 would return true only if Mike is the persons friend, or friend of a friend
+   */
+  hasDeep(
+    property: NamedNode,
+    value: Node,
+    maxDepth: number = Infinity,
+  ): boolean {
+    var checked = new NodeSet();
+    var stack = new NodeSet([this as Node]);
+    while (stack.size > 0 && maxDepth > 0) {
+      var nextLevelStack = new NodeSet();
+      for (let node of stack) {
+        for (var propertyValue of node.getAll(property)) {
+          if (propertyValue === value) {
+            return true;
+          }
+          if (!checked.has(propertyValue)) {
+            checked.add(propertyValue);
+            nextLevelStack.add(propertyValue);
+          }
+        }
+      }
+      stack = nextLevelStack;
+      maxDepth--;
+    }
+    return false;
+  }
+
+  /**
+   * Returns the first node that has this node as the valu eof the given property.
+   * Same as getOne() but for 'inverse properties'. Meaning nodes that have this node as their value.
+   * Example: if this is a person. this.getOneInverse(hasChild) returns one of the persons parents
+   * NOTE: the order of multiple (inverse) values CANNOT be guaranteed. Therefore use this value if it DOESN'T matter to you which of multiple possible inverse values for this property you'll get OR if you're certain there will be only one value.
+   * @param property - a NamedNode with rdf:type rdf:Property, the edge in the graph, the predicate of a quad
+   */
+  getOneInverse(property: NamedNode): NamedNode | undefined {
+    if (!this.asObject) return undefined;
+    var quads: QuadMap = this.asObject.get(property);
+    return quads ? (quads.keys().next().value as NamedNode) : undefined;
+  }
+
+  /**
+   * Returns all the nodes that have this node as the value of the given property.
+   * Same as getAll() but for 'inverse properties'. Meaning nodes that have this node as their value.
+   * Example: if this is a person. this.getAllInverse(hasChild) returns all the persons parents
+   * @param property - a NamedNode with rdf:type rdf:Property, the edge in the graph, the predicate of a quad
+   */
+  getAllInverse(property: NamedNode): NodeSet<NamedNode> {
+    if (!this.asObject || !this.asObject.has(property))
+      return new NodeSet<NamedNode>();
+    return this.asObject.get(property).getSubjects();
+  }
+
+  /**
+   * Returns all the nodes that have this node as the EXPLICIT value of the given property.
+   * Same as getAll() but only considers explicit facts (excluding implicit facts generated by the reasoner)
+   * Example: if this is a person. this.getAllInverse(hasChild) returns all the persons parents, as long as the fact that these are this persons parents is explicitly stated
+   * @param property - a NamedNode with rdf:type rdf:Property, the edge in the graph, the predicate of a quad
+   */
+  getAllInverseExplicit(property): NodeSet<NamedNode> {
+    return this.getExplicitInverseQuads(property).getSubjects();
+  }
+
+  /**
+   * Get all the values of multiple properties at once
+   * Same as getAll() but for multiple properties at once
+   * @param property - a NamedNode with rdf:type rdf:Property, the edge in the graph, the predicate of a quad
+   */
+  getMultiple(properties: ICoreIterable<NamedNode>): NodeSet {
+    var res = new NodeSet();
+    for (var property of properties) {
+      res = res.concat(this.getAll(property));
+    }
+    return res;
+  }
+
+  /**
+   * Get all the nodes that have this node as their value for any of the given properties
+   * Same as getMultiple() but for the opposite direction
+   * @param property - a NamedNode with rdf:type rdf:Property, the edge in the graph, the predicate of a quad
+   */
+  getMultipleInverse(properties: ICoreIterable<NamedNode>): NodeSet {
+    var res = new NodeSet();
+    for (var property of properties) {
+      res = res.concat(this.getAllInverse(property));
+    }
+    return res;
+  }
+
+  /**
+   * Get the quad that represent the connection from this node to the given value, connected by the given property
+   * NOTE: accessing quads is a very low level functionality required for the framework itself
+   * and SHOULD GENERALLY NOT BE USED. Use methods to get/set properties instead
+   * @param property - a NamedNode with rdf:type rdf:Property, the edge in the graph, the predicate of a quad
+   * @param value - the node that this new graph-edge points to. The object of the quad to be created.
+   */
+  getQuads(property: NamedNode, value?: Node): QuadSet {
+    if (!this.asSubject.has(property)) return new QuadSet();
+    if (value) {
+      return this.getQuadsByValue(property, value);
+    } else {
+      return this.asSubject.get(property).getQuadSet();
+    }
+  }
+
+  /**
+   * Get all the quads that represent EXPLICIT connections from this node to another node, connected by the given property
+   * NOTE: accessing quads is a very low level functionality required for the framework itself
+   * and SHOULD GENERALLY NOT BE USED. Use methods to get/set properties instead
+   * @param property - a NamedNode with rdf:type rdf:Property, the edge in the graph, the predicate of a quad
+   */
+  getExplicitQuads(property: NamedNode): QuadSet {
+    return this.getQuads(property).filter((quad) => !quad.implicit);
+  }
+
+  /**
+   * Get all the quads that represent EXPLICIT connections from another node that has this node as its value for the given property
+   * NOTE: accessing quads is a very low level functionality required for the framework itself
+   * and SHOULD GENERALLY NOT BE USED. Use methods to get/set properties instead
+   * @param property - a NamedNode with rdf:type rdf:Property, the edge in the graph, the predicate of a quad
+   */
+  getExplicitInverseQuads(property: NamedNode): QuadSet {
+    return this.getInverseQuads(property).filter((quad) => !quad.implicit);
+  }
+
+  /**
+   * Get all quads that represent connections from another node that has this node as its value for the given property
+   * NOTE: accessing quads is a very low level functionality required for the framework itself
+   * and SHOULD GENERALLY NOT BE USED. Use methods to get/set properties instead
+   * @param property - a NamedNode with rdf:type rdf:Property, the edge in the graph, the predicate of a quad
+   */
+  getInverseQuads(property: NamedNode): QuadSet | undefined {
+    if (!this.asObject.has(property)) return undefined;
+    return this.asObject.get(property).getQuadSet();
+    // return this.asObject && this.asObject.has(property)
+    // 	? this.asObject.get(property)
+    // 	: new QuadMap();
+  }
+
+  /**
+   * Get all (by default explicit) quads that represent connections from another node that has this node as its value for ANY property
+   * NOTE: accessing quads is a very low level functionality required for the framework itself
+   * and SHOULD GENERALLY NOT BE USED. Use methods to get/set properties instead
+   * @param includeImplicit if true, includes both implicit and explicit quads. By default false, so will only return explicit quads
+   */
+  getAllInverseQuads(includeImplicit: boolean = false): QuadArray {
+    var res: QuadArray = new QuadArray();
+    if (this.asObject) {
+      this.asObject.forEach((quadSet) => {
+        quadSet.forEach((quad) => {
+          if (!includeImplicit && quad.implicit) return;
+          res.push(quad);
+        });
+      });
+    }
+    return res;
+  }
+
+  /**
+   * Get all (by default explicit) quads that represent connections for all values of this node (so quads where this node is the subject)
+   * NOTE: accessing quads is a very low level functionality required for the framework itself
+   * and SHOULD GENERALLY NOT BE USED. Use methods to get/set properties instead
+   * @param includeAsObject if true, includes quads from both directions (so also inverse properties where this node is the object of the quad)
+   * @param includeImplicit if true, includes both implicit and explicit quads. By default false, so will only return explicit quads
+   */
+  getAllQuads(
+    includeAsObject: boolean = false,
+    includeImplicit: boolean = false,
+  ): QuadArray {
+    var res: QuadArray = new QuadArray();
+    this.asSubject.forEach((quadMap) => {
+      quadMap.forEach((quad) => {
+        if (!includeImplicit && quad.implicit) return;
+        res.push(quad);
+      });
+    });
+    if (includeAsObject && this.asObject) {
+      this.asObject.forEach((quadMap) => {
+        quadMap.forEach((quad) => {
+          //we manually filter duplicates from the result set here so that we can keep using QuadArray, which is much faster in ES5
+          //and the only duplicates will be a node with itself as subject AND object, so we filter the second occurrence here
+          if (!includeImplicit && quad.implicit) return;
+          if (quad.subject === this) return;
+          res.push(quad);
+        });
+      });
+    }
+    return res;
+  }
+
+  /**
+   * #######################################################################
+   * ######################## EVENT METHODS / LISTENERS ####################
+   * #######################################################################
+   **/
+
+  /**
+   * Update a certain property so that only the given value is a value of this property.
+   * Overwrites (and thus removes) any previously set values
+   * @param property - a NamedNode with rdf:type rdf:Property, the edge in the graph, the predicate of a quad
+   * @param value - a single node. Can be a NamedNode or Literal
+   */
+  overwrite(property: NamedNode, value: Node): boolean {
+    //don't do anything if the current value is already equivalent to the new value
+    if (this.getAll(property).size == 1 && value && this.has(property, value))
+      return false;
+
+    //clear all values and set new value
+    this.unsetAll(property);
+    if (value) {
+      return this.set(property, value);
+    }
+  }
+
+  /**
+   * Update a certain property so that only the given values are the values of this property.
+   * Overwrites (and thus removes) any previously set values
+   * Same as overwrite() except this allows you to replace the previous values with MULTIPLE new values
+   * @param property
+   * @param values
+   */
+  moverwrite(property: NamedNode, values: ICoreIterable<Node>): boolean {
+    //don't update if the new set of values is the same (or equivalent) as the old set of values
+    if (
+      this.getAll(property).size === (values.size || values.length) &&
+      values.every((value) => this.has(property, value))
+    ) {
+      return false;
+    }
+    this.unsetAll(property);
+    return this.mset(property, values);
+  }
+
+  /**
+   * Removes this node from the graph, locally and remotely, in all connected QuadStores.
+   * All properties will be unset, both where this node is the subject or the object.
+   * Emits an event from the node itself and from the NamedNode class
+   */
+  remove() {
+    //collect all the quads that are about to be removed
+    let removedQuads = this.getAllQuads(true);
+
+    //remove all quads locally
+    this.asSubject.forEach((quads) => quads.removeAll(true));
+    if (this.asObject) this.asObject.forEach((quads) => quads.removeAll(true));
+
+    //emit event from this node itself, with all the quads that were removed
+    this.emit(NamedNode.NODE_REMOVED, this, removedQuads);
+    //clean up anything connected to this node
+    this.removeAllListeners();
+
+    //remove form list
+    NamedNode.unregister(this);
+
+    //make sure a global event is emitted that nodes are moved (picked up by storage)
+    eventBatcher.register(NamedNode);
+    NamedNode.nodesToRemove.add([this, removedQuads]);
+  }
+
+  /**
+   * UNSET (remove) a single property value connection.
+   * Remove a single connection between two nodes in the graph: from this node, to the node given as value, with the property as the connecting 'edge' between them
+   * In the graph, this will remove the edge between two nodes.
+   * @param property - a NamedNode with rdf:type rdf:Property, the edge in the graph, the predicate of a quad
+   * @param value - the node that this new graph-edge points to. The object of the quad to be created.
+   */
+  unset(property: NamedNode, value: Node): boolean {
+    if (this.has(property, value)) {
+      this.getQuads(property, value).removeAll(true);
+      return true;
+    }
+    return false;
+  }
+
+  /**
+   * unset (remove) all values of a certain property.
+   * Removes all connections (edges) in the graph between this node and other nodes, where the given property is used as the connecting 'edge' between them
+   * @param property - a NamedNode with rdf:type rdf:Property, the edge in the graph, the predicate of a quad
+   */
+  unsetAll(property: NamedNode): boolean {
+    NamedNode.emitClearedProperty(this, property);
+    if (this.hasProperty(property)) {
+      //false as parameter because we don't need alteration events for each single quad, but rather manage this with clearedProperties events
+      this.asSubject.get(property).removeAll(false);
+      return true;
+    }
+    return false;
+  }
+
+  /**
+   * returns true if ANY node has this node as the value of the given property
+   * Example: if 'this' is a person, this.hasInverseProperty(hasChild) returns true if any facts stating `someParent hasChild thisPerson` are known
+   * @param property - a NamedNode with rdf:type rdf:Property, the edge in the graph, the predicate of a quad
+   */
+  hasInverseProperty(property: NamedNode): boolean {
+    return this.asObject && this.asObject.has(property);
+  }
+
+  /**
+   * returns true if the given inverse 'value' has this node as the (real) value of the given property
+   * Example: if 'this' is a person, this.hasInverseProperty(hasChild,someParent) returns true if someParent indeed has this person as a child
+   * @param property - a NamedNode with rdf:type rdf:Property, the edge in the graph, the predicate of a quad
+   * @param value - a single node. Can be a NamedNode or Literal
+   */
+  hasInverse(property: NamedNode, value: Node): boolean {
+    return (
+      this.asObject &&
+      this.asObject.get(property)?.some((quad) => quad.subject.equals(value))
+    );
+  }
+
+  /**
+   * returns true if this node is equivaluent to the given node.
+   * For NamedNodes it simply returns true if this === the given object. So if its the same object in memory.
+   * It exists mainly for comparing Literals, where two different objects can still be equivalent
+   * @param other another node
+   */
+  equals(other: Term): boolean {
+    return other === this;
+  }
+
+  /**
+   * Save this node into the graph database.
+   * Newly created nodes will exist only in local memory until you call this function
+   * @returns a promise that resolves when the node has received a permanent URI
+   */
+  save(): Promise<void> {
+    if (this.isTemporaryNode) {
+      if (!this._isStoring) {
+        //this creates a promise that will resolve when the node is stored
+        this.isStoring = true;
+        NamedNode.nodesToSave.add(this);
+        eventBatcher.register(NamedNode);
+      }
+      //always return a promise
+      return this._isStoring.promise;
+    }
+  }
+
+  /**
+   * Create a new URI Node with the same properties as the current node
+   * NOTE: does NOT clone the inverse properties (where this node is the value of another node its properties)
+   */
+  clone(): NamedNode {
+    var node = NamedNode.create();
+    this.getAllQuads().forEach((quad: Quad) => {
+      node.set(quad.predicate, quad.object);
+    });
+    return node as this;
+  }
+
+  /**
+   * Returns a string representation of this node.
+   * Returns the URI for a NamedNode
+   */
+  toString() {
+    return this.uri;
+  }
+
+  print(includeIncomingProperties: boolean = true) {
+    var print = '';
+    this.getAsSubjectQuads().forEach((quadMap) => {
+      BlankNode.includeBlankNodes(quadMap.getQuadSet()).forEach(
+        (quad) => (print += '\t' + quad.print() + '.\n'),
+      );
+    });
+    if (this.asObject && includeIncomingProperties) {
+      print += '<----\n';
+      this.asObject.forEach((quadMap) => {
+        BlankNode.includeBlankNodes(quadMap.getQuadSet(), false, true).forEach(
+          (quad) => (print += '\t' + quad.print() + '.\n'),
+        );
+      });
+    }
+    return print;
+  }
+
+  /**
+   * Fires the given call back when ANY property of this node changes.
+   * @param callback the method to be called when the change happens. The quads that have changed + the property that was updated are supplied as parameters
+   * @param context give a context to make sure you can easily unset / clear event listeners. Usually you would provide 'this' as context
+   */
+  onChangeAny(
+    callback: (quads?: QuadSet, property?: NamedNode) => void,
+    context?: any,
+  ) {
+    this.on(NamedNode.PROPERTY_CHANGED, callback, context);
+  }
+
+  /**
+   * Fires the given call back when this node become the value or is no longer the value of another node
+   * @param callback the method to be called when the change happens. The quads that have changed + the property that was updated are supplied as parameters
+   * @param context give a context to make sure you can easily unset / clear event listeners. Usually you would provide 'this' as context
+   */
+  onChangeAnyInverse(
+    callback: (quads?: QuadSet, property?: NamedNode) => void,
+    context?: any,
+  ) {
+    this.on(NamedNode.INVERSE_PROPERTY_CHANGED, callback, context);
+  }
+
+  /**
+   * Fires the given call back when this node changes the values of the given property
+   * @param callback the method to be called when the change happens. The quads that have changed + the property that was updated are supplied as parameters
+   * @param context give a context to make sure you can easily unset / clear event listeners. Usually you would provide 'this' as context
+   */
+  onChange(
+    property: NamedNode,
+    callback: (quads?: QuadSet, property?: NamedNode) => void,
+    context?: any,
+  ) {
+    this.on(NamedNode.PROPERTY_CHANGED + property.uri, callback, context);
+  }
+
+  /**
+   * Fires the given callback when this node become the value or is no longer the value of the given property of another node
+   * Example: if someGroup hasParticipant thisResource, and the group removes this node from its participants, it will trigger onChangeInverse for this node
+   * @param callback the method to be called when the change happens. The quads that have changed + the property that was updated are supplied as parameters
+   * @param context give a context to make sure you can easily unset / clear event listeners. Usually you would provide 'this' as context
+   */
+  onChangeInverse(
+    property,
+    callback: (quads?: QuadSet, property?: NamedNode) => void,
+    context?: any,
+  ) {
+    this.on(
+      NamedNode.INVERSE_PROPERTY_CHANGED + property.uri,
+      callback,
+      context,
+    );
+  }
+
+  /**
+   * Call this when you want to stop listening for onChangeAny events. Make sure to provide the exact same BOUND instance of a method to properly clear the listener. OR make sure to provide a context both when setting and clearing the listener.
+   * @param callback the exact same method you supplied to onChangeAny
+   * @param context the same context you supplied to onChangeAny
+   */
+  removeOnChangeAny(
+    callback: (quads?: QuadSet, property?: NamedNode) => void,
+    context?: any,
+  ) {
+    this.off(NamedNode.PROPERTY_CHANGED, callback, context);
+  }
+
+  /**
+   * Call this when you want to stop listening for onChangeAnyInverse events. Make sure to provide the exact same BOUND instance of a method to properly clear the listener. OR make sure to provide a context both when setting and clearing the listener.
+   * @param callback the exact same method you supplied to onChangeAnyInverse
+   * @param context the same context you supplied to onChangeAnyInverse
+   */
+  removeOnChangeAnyInverse(
+    callback: (quads?: QuadSet, property?: NamedNode) => void,
+    context?: any,
+  ) {
+    this.off(NamedNode.INVERSE_PROPERTY_CHANGED, callback, context);
+  }
+
+  /**
+   * Call this when you want to stop listening for onChange events. Make sure to provide the exact same BOUND instance of a method as callback to properly clear the listener. OR make sure to provide a context both when setting and clearing the listener.
+   * @param callback the exact same method you supplied to onChange
+   * @param context the same context you supplied to onChange
+   */
+  removeOnChange(
+    property: NamedNode,
+    callback: (quads?: QuadSet, property?: NamedNode) => void,
+    context?: any,
+  ) {
+    this.off(NamedNode.PROPERTY_CHANGED + property.uri, callback, context);
+  }
+
+  /* #######################################################################
+   * ######################### STATIC METHODS ##############################
+   * #######################################################################
+   */
+
+  /**
+   * Call this when you want to stop listening for onChangeInverse events. Make sure to provide the exact same BOUND instance of a method as callback to properly clear the listener. OR make sure to provide a context both when setting and clearing the listener.
+   * @param callback the exact same method you supplied to onChangeInverse
+   * @param context the same context you supplied to onChangeInverse
+   */
+  removeOnChangeInverse(
+    property,
+    callback: (quads?: QuadSet, property?: NamedNode) => void,
+    context?: any,
+  ) {
+    this.off(
+      NamedNode.INVERSE_PROPERTY_CHANGED + property.uri,
+      callback,
+      context,
+    );
+  }
+
+  /**
+   * Call this when you want to stop listening for onChangeAny events. Other then removeOnChangeAny you only have to supply the context.
+   * Use this if you no longer have access to the same bound listener function or you're otherwise unable to clear with removeOnChangeAny
+   * @param context the same context you supplied to onChangeAny
+   */
+  clearOnChangeAny(context: any) {
+    this.removeListenerByContext(NamedNode.PROPERTY_CHANGED, context);
+  }
+
+  /**
+   * Call this when you want to stop listening for onChangeAnyInverse events. Other then removeOnChangeAnyInverse you only have to supply the context.
+   * Use this if you no longer have access to the same bound listener function or you're otherwise unable to clear with removeOnChangeAnyInverse
+   * @param context the same context you supplied to onChangeAnyInverse
+   */
+  clearOnChangeAnyInverse(context: any) {
+    this.removeListenerByContext(NamedNode.INVERSE_PROPERTY_CHANGED, context);
+  }
+
+  /**
+   * Call this when you want to stop listening for onChange events. Other then removeOnChange you only have to supply the context.
+   * Use this if you no longer have access to the same bound listener function or you're otherwise unable to clear with removeOnChange
+   * @param context the same context you supplied to onChange
+   */
+  clearOnChange(property: NamedNode, context?: any) {
+    this.removeListenerByContext(
+      NamedNode.PROPERTY_CHANGED + property.uri,
+      context,
+    );
+  }
+
+  /**
+   * Call this when you want to stop listening for onChangeInverse events. Other then removeOnChangeInverse you only have to supply the context.
+   * Use this if you no longer have access to the same bound listener function or you're otherwise unable to clear with removeOnChangeInverse
+   * @param context the same context you supplied to onChangeAny
+   */
+  clearOnChangeInverse(property, context: any) {
+    this.removeListenerByContext(
+      NamedNode.INVERSE_PROPERTY_CHANGED + property.uri,
+      context,
+    );
+  }
+
+  /**
+   * Call this when you want to stop listening for onPredicateChange events
+   * @param context the same context you supplied to onPredicateChange
+   */
+  clearOnPredicateChange(context: any) {
+    this.removeListenerByContext(NamedNode.AS_PREDICATE_CHANGED, context);
+  }
+
+  /**
+   * Emits the batched (property) events of a NamedNode INSTANCE (meaning for this specific node)
+   * Used internally by the framework to manage emitting change events
+   * @internal
+   */
+  emitBatchedEvents() {
+    //for each type of property change (and the map of batched changes for that type of change)
+    [
+      [this.changedProperties, NamedNode.PROPERTY_CHANGED],
+      [this.changedInverseProperties, NamedNode.INVERSE_PROPERTY_CHANGED],
+      [this.alteredProperties, NamedNode.PROPERTY_ALTERED],
+      [this.alteredInverseProperties, NamedNode.INVERSE_PROPERTY_ALTERED],
+    ].forEach(([map, event]: [CoreMap<NamedNode, QuadSet>, string]) => {
+      if (!map) return;
+      //for each individual change that was made
+      map.forEach((quads: QuadSet, property: NamedNode) => {
+        //emit the specific event that THIS property has changed
+        this.emit(event + property.uri, quads, property);
+      });
+
+      if (map.size > 0) {
+        //emit the general event that A property has changed/altered
+        this.emit(event, map);
+      }
+      map.clear();
+    });
+
+    // if (this.changedAsPredicate) {
+    //   this.emit(NamedNode.AS_PREDICATE_CHANGED, this.changedAsPredicate, this);
+    //   this.changedAsPredicate = null;
+    // }
+    // if (this.alteredAsPredicate) {
+    //   this.emit(NamedNode.AS_PREDICATE_ALTERED, this.alteredAsPredicate, this);
+    //   this.alteredAsPredicate = null;
+    // }
+  }
+
+  getAsSubjectQuads() {
+    return this.asSubject;
+  }
+
+  getAsObjectQuads() {
+    return this.asObject;
+  }
+
+  // getAsPredicateQuads() {
+  //   return this.asPredicate;
+  // }
+
+  private createPromise() {
+    var resolve, reject;
+    var promise = new Promise((res, rej) => {
+      resolve = res;
+      reject = rej;
+    });
+    return {promise, resolve, reject};
+  }
+
+  /**
+   * Adds the quad to all given maps
+   * @param quad
+   * @param maps
+   * @private
+   */
+  private registerPropertyChange(quad: Quad, maps: Map<NamedNode, QuadSet>[]) {
+    //register that this class has some events to emit
+    eventBatcher.register(this);
+    //for each given map
+    maps.forEach((map) => {
+      //add this quad under the predicate as key
+      if (!map.has(quad.predicate)) {
+        map.set(quad.predicate, new QuadSet());
+      }
+      map.get(quad.predicate).add(quad);
+    });
+  }
+
+  // private registerPredicateChange(quad: Quad, alteration: boolean) {
+  //   eventBatcher.register(this);
+  //   if (!this.changedAsPredicate) {
+  //     this.changedAsPredicate = new QuadArray();
+  //   }
+  //   this.changedAsPredicate.push(quad);
+  //   if (alteration) {
+  //     if (!this.alteredAsPredicate) {
+  //       this.alteredAsPredicate = new QuadArray();
+  //     }
+  //     this.alteredAsPredicate.push(quad);
+  //   }
+  // }
+
+  private getQuadsByValue(property: NamedNode, value?: Node): QuadSet {
+    return value instanceof NamedNode
+      ? this.asSubject.get(property).has(value)
+        ? this.asSubject.get(property).get(value)
+        : new QuadSet()
+      : this.asSubject
+          .get(property)
+          .filter((quad) => quad.object.equals(value), QuadSet);
+  }
+}
+
+//cannot import from xsd ontology here without creating circular dependencies
+var rdfLangString: NamedNode = NamedNode.getOrCreate(
+  'http://www.w3.org/1999/02/22-rdf-syntax-ns#langString',
+);
+var xsdString: NamedNode = NamedNode.getOrCreate(
+  'http://www.w3.org/2001/XMLSchema#string',
+);
+
+export class BlankNode extends NamedNode {
+  private static counter: number = 0;
+
+  termType: any = 'BlankNode';
+
+  constructor(uri?: string, isTemporaryNode: boolean = false) {
+    super(uri || BlankNode.createUri(), isTemporaryNode);
+    NamedNode.register(this);
+  }
+
+  get uri(): string {
+    return this._value;
+  }
+
+  set uri(uri: string) {
+    throw new Error(
+      'You should not set the URI of a BlankNode. Make sure the node is created as a NamedNode. BlankNode data:\n' +
+        BlankNode.includeBlankNodes(this.getAllQuads()).toString(),
+    );
+  }
+
+  static create(isTemporaryNode: boolean = false): BlankNode {
+    return new BlankNode(null, isTemporaryNode);
+  }
+
+  static createUri() {
+    return '_:' + this.counter++;
+  }
+
+  static includeBlankNodes(
+    quads: QuadSet | Quad[],
+    includeObjectBlankNodes: boolean = true,
+    includeSubjectBlankNodes: boolean = false,
+    blankNodes: NodeURIMappings = new NodeURIMappings(),
+  ) {
+    let add =
+      quads instanceof Set ? quads.add.bind(quads) : quads.push.bind(quads);
+    quads.forEach((quad) => {
+      if (includeObjectBlankNodes && quad.object instanceof BlankNode) {
+        this.addBlankNodeQuads(quad.object, add, blankNodes);
+      }
+      if (includeSubjectBlankNodes && quad.subject instanceof BlankNode) {
+        //also add quads of subjects that are blank nodes, iteratively, but don't include the blank node objects of those quads
+        this.addBlankNodeQuads(quad.subject, add, blankNodes, true);
+      }
+    });
+    return quads;
+  }
+
+  private static addBlankNodeQuads(
+    blankNode: BlankNode,
+    add: (n: any) => void,
+    blankNodes: NodeURIMappings,
+    inverseIteration: boolean = false,
+  ) {
+    // console.log('adding quads of ' + blankNode.uri);
+    blankNodes.set(blankNode.uri, blankNode);
+    blankNode.getAllQuads().forEach((quad) => {
+      if (!(quad instanceof Quad)) {
+        throw new Error('Not a quad');
+      }
+      add(quad);
+      //also, iteratively include quads of blank-node values of blank-nodes
+      if (!inverseIteration && quad.object instanceof BlankNode) {
+        //if we've not seen this blank node yet during this collection (avoiding loops from circular references between blank nodes)
+        if (!blankNodes.has(quad.object.uri)) {
+          this.addBlankNodeQuads(quad.object, add, blankNodes);
+        }
+      }
+      if (inverseIteration && quad.subject instanceof BlankNode) {
+        //if we've not seen this blank node yet during this collection (avoiding loops from circular references between blank nodes)
+        if (!blankNodes.has(quad.subject.uri)) {
+          this.addBlankNodeQuads(quad.subject, add, blankNodes, true);
+        }
+      }
+    });
+  }
+}
+
+/**
+ * One of the two main classes of nodes (nodes) in the graph.
+ * Literals are endpoints. They do NOT have outgoing connections (edges) to other nodes in the graph.
+ * Though a NamedNode can point to a Literal.
+ * Each literal node has a literal value, like a string.
+ * Besides that is can also have a language tag or a data type.
+ * Literals are often saved as a single string, for example '"yes"@en' (yes in english) or '"true"^^xsd:boolean (the value true with datatype english)
+ * This class represents those properties.
+ * See also: https://www.w3.org/TR/rdf-concepts/#section-Graph-Literal
+ */
+export class Literal extends Node implements IGraphObject, ILiteral {
+  termType: 'Literal' = 'Literal';
+  private referenceQuad: Quad;
+
+  /**
+   * Other than with NamedNodes, its fine to do `new Literal("my string value")`
+   * Datatype and language tags are optional
+   * @param value
+   * @param datatype
+   * @param language
+   */
+  constructor(
+    value: string,
+    protected _datatype: NamedNode = null,
+    private _language: string = '',
+  ) {
+    super(value);
+    if (typeof value !== 'string') {
+      throw new Error(
+        'Literal value must be a string. Given value was a ' +
+          typeof value +
+          ' (' +
+          value +
+          ')',
+      );
+    }
+  }
+
+  /**
+   * get the language tag of this literal which states which language this literal is written in
+   * See also: http://www.iana.org/assignments/language-subtag-registry/language-subtag-registry
+   */
+  get language(): string {
+    //list of language tags: http://www.iana.org/assignments/language-subtag-registry/language-subtag-registry
+    return this._language;
+  }
+
+  /**
+   * update the language tag of this literal
+   */
+  set language(lang: string) {
+    this._language = lang;
+
+    //the datatype of any literal with a language tag is rdf:langString
+    this._datatype = rdfLangString;
+  }
+
+  /**
+   * returns the datatype of this literal
+   * Note that datatypes are NamedNodes themselves, who always have rdf:type rdf:Datatype
+   * If no datatype is set, the default datatype xsd:string will be returned
+   * If a language tag is set, the returned datatype will be rdf:langString
+   */
+  get datatype(): NamedNode {
+    if (this._datatype) {
+      return this._datatype;
+    }
+    //default datatype is xsd:string, if language is set this.datatype should be langString already
+    return xsdString;
+  }
+
+  /**
+   * Update the datatype of this literal
+   * @param datatype
+   */
+  set datatype(datatype: NamedNode) {
+    this._datatype = datatype;
+  }
+
+  /**
+   * Return the value of this literal
+   * @param datatype
+   */
+  get value(): string {
+    return this._value;
+  }
+
+  /**
+   * update the literal value of this literal
+   * @param datatype
+   */
+  set value(value: string) {
+    let previousValue: Literal;
+    //if this literal is being used in a quad
+    if (this.referenceQuad) {
+      //remember the previous value for the events below
+      previousValue = this.clone();
+    }
+    //update the value
+    this._value = value;
+    if (this.referenceQuad) {
+      //register change for subject node (for node.onChange(prop) listeners)
+      this.referenceQuad.subject.registerValueChange(this.referenceQuad, true);
+      //notify the graph of a change (will mimic a removed and added quad)
+      // this.referenceQuad.graph.registerQuadValueChange(previousValue,this.referenceQuad);
+      //notify the quad that the value of it's object has changed (will mimic a removed and added quad)
+      this.referenceQuad.onValueChanged(previousValue);
+    }
+  }
+
+  /**
+   * Returns the literal value of the first Literal that occurs as object for the given subject and property and optionally also matches the given language
+   * @param subject
+   * @param property
+   * @param language
+   * @deprecated
+   * @returns {string|undefined}
+   */
+  static getValue(
+    subject: NamedNode,
+    property: NamedNode,
+    language: string = '',
+  ): string | undefined {
+    for (var value of subject.getAll(property)) {
+      if (
+        value instanceof Literal &&
+        (!language || value.isOfLanguage(language))
+      ) {
+        return value.value;
+      }
+    }
+    return undefined;
+  }
+
+  /**
+   * Returns all literal values of the Literals that occur as object for the given subject and property and optionally also match the given language
+   * @param subject
+   * @param property
+   * @param language
+   * @returns {string[]}
+   */
+  static getValues(
+    subject: NamedNode,
+    property: NamedNode,
+    language: string = '',
+  ): string[] {
+    var res = [];
+    for (var value of subject.getAll(property)) {
+      if (
+        value instanceof Literal &&
+        (!language || value.isOfLanguage(language))
+      ) {
+        res.push(value.value);
+      }
+    }
+    return res;
+  }
+
+  static isLiteralString(literalString: string): boolean {
+    var regex = new RegExp(
+      '(\\"[^\\"^\\n]*\\")(@[a-z]{1,3}|\\^\\^[a-zA-Z]+\\:[a-zA-Z0-9_-]+|\\<https?:\\/\\/(www\\.)?[-a-zA-Z0-9@:%._\\+~#=]{2,256}\\.[a-z]{2,6}\\b([-a-zA-Z0-9@:%_\\+.~#?&//=]*)\\>)?',
+    );
+    return regex.test(literalString);
+  }
+
+  static fromString(literalString: string): Literal {
+    //self made regex thatL
+    // match anything between quotes or quad quotes (the quotes are group 1 and 3)
+    // except escaped quotes (2)
+    //and everything behind it (4) for language or datatype
+    //..with a little help on the escaped quotes from here
+    //https://stackoverflow.com/questions/38563414/javascript-regex-to-select-quoted-string-but-not-escape-quotes
+
+    let match = literalString.match(
+      /("|""")([^"\\]*(?:\\.[^"\\]*)*)("|""")(.*)/,
+    );
+
+    //NOTE: if \n replacement turns out to be not correct here it should at least be moved to JSONLDParser, see https://github.com/digitalbazaar/jsonld.js/issues/242
+    let literal = (match[2] ? match[2] : '')
+      .replace(/\\"/g, '"')
+      .replace(/\\n/g, '\n');
+    let suffix = match[4];
+    if (!suffix) {
+      return new Literal(literal);
+    }
+    if (suffix[0] == '@') {
+      return new Literal(literal, null, suffix.substr(1));
+    } else if (suffix[0] == '^') {
+      var datatype = NamedNode.fromString(suffix.substr(2));
+      return new Literal(literal, datatype);
+    } else {
+      throw new Error('Invalid literal string format: ' + literalString);
+    }
+  }
+
+  getAs<T extends IShape>(type: {new (): T; getOf(node: Node): T}): T {
+    return type.getOf(this);
+  }
+
+  /**
+   * @internal
+   * @param quad
+   */
+  registerProperty(quad: Quad): void {
+    throw new Error('Literal nodes should not be used as subjects');
+  }
+
+  /**
+   * registers the use of a quad. Since a quad can only be used in 1 quad
+   * this method makes a clone of the Literal if it's used a second time,
+   * and returns that new Literal so it will be used by the quad
+   * @internal
+   * @param quad
+   */
+  registerInverseProperty(quad: Quad): Node {
+    //if this Literal is already being used in another quad
+    if (this.referenceQuad) {
+      //then return a clone
+      //(this allows things like a.set(label,b.getOne(label)))
+      return this.clone().registerInverseProperty(quad);
+    }
+    this.referenceQuad = quad;
+    return this;
+  }
+
+  /**
+   * @internal
+   * @param quad
+   */
+  unregisterProperty(quad: Quad): void {
+    throw new Error('Literal nodes should not be used as subjects');
+  }
+
+  /**
+   * @internal
+   * @param quad
+   */
+  unregisterInverseProperty(quad: Quad): void {
+    this.referenceQuad = null;
+  }
+
+  /**
+   * returns true if this literal node has a language tag
+   */
+  hasLanguage(): boolean {
+    return this._language != '';
+  }
+
+  /**
+   * returns true if the language tag of this literal matches the given language
+   */
+  isOfLanguage(language: string) {
+    return this._language === language;
+  }
+
+  /**
+   * returns true if this literal has a datatype
+   */
+  hasDatatype(): boolean {
+    //checks for null and undefined
+    return this._datatype != null;
+  }
+
+  /**
+   * Returns true if both are literal nodes, with equal literal values, equal language tags and equal data types
+   * Other than NamedNodes, two different literal node instances can be deemed equivalent if all their properties are the same
+   * @param other
+   * @param caseSensitive
+   */
+  equals(other: Term): boolean {
+    return this._equals(other);
+  }
+
+  /**
+   * Returns true if both are literal nodes, with equal literal values (CASE INSENSITIVE CHECK), equal language tags and equal data types
+   * Other than NamedNodes, two different literal node instances can be deemed equivalent if all their properties are the same
+   * @param other
+   */
+
+  equalsCaseInsensitive(other: Term) {
+    return this._equals(other, false);
+  }
+
+  /**
+   * Creates a new Literal with exact the same properties (value,datatype and language)
+   */
+  clone(): Literal {
+    return new Literal(this._value, this.datatype, this.language) as this;
+  }
+
+  getReferenceQuad() {
+    return this.referenceQuad;
+  }
+
+  hasInverseProperty(property: NamedNode): boolean {
+    return this.referenceQuad && this.referenceQuad.predicate === property;
+  }
+
+  hasInverse(property: NamedNode, value: Node): boolean {
+    return (
+      this.referenceQuad &&
+      this.referenceQuad.predicate === property &&
+      this.referenceQuad.subject === value
+    );
+  }
+
+  getOneInverse(property: NamedNode): NamedNode | undefined {
+    return this.referenceQuad && this.referenceQuad.predicate === property
+      ? this.referenceQuad.subject
+      : undefined;
+  }
+
+  getMultipleInverse(properties: ICoreIterable<NamedNode>): NodeSet<NamedNode> {
+    if (properties.find((p) => p === this.referenceQuad.predicate)) {
+      return new NodeSet<NamedNode>([this.referenceQuad.subject]);
+    }
+    return new NodeSet<NamedNode>();
+  }
+
+  getAllInverseQuads(includeImplicit?: boolean): QuadArray {
+    return !includeImplicit || !this.referenceQuad.implicit
+      ? new QuadArray(this.referenceQuad)
+      : new QuadArray();
+  }
+
+  getAllQuads(
+    includeAsObject: boolean = false,
+    includeImplicit: boolean = false,
+  ): QuadArray {
+    return includeAsObject && (!includeImplicit || !this.referenceQuad.implicit)
+      ? new QuadArray(this.referenceQuad)
+      : new QuadArray();
+  }
+
+  promiseLoaded(loadInverseProperties: boolean = false): Promise<boolean> {
+    return Promise.resolve(true);
+  }
+
+  isLoaded(includingInverseProperties: boolean = false): boolean {
+    return true;
+  }
+
+  toString(): string {
+    //quotes are needed to differentiate the literal "http://test.com" from the URI http://test.com, so the literal value is always surrounded by quotes
+    //quad quotes are needed in case of newlines
+    // let quotes = this._value.indexOf("\n") != -1 ? '"""' : '"';
+    let quotes = '"';
+    let suffix = '';
+    if (this.hasLanguage()) {
+      suffix = '@' + this.language;
+    } else if (this.hasDatatype()) {
+      suffix = '^^<' + this.datatype.uri + '>';
+    }
+    //quotes in the value need to be escaped
+    return (
+      quotes +
+      this._value.replace(/\"/g, '\\"').replace(/\n/g, '\\n') +
+      quotes +
+      suffix
+    );
+  }
+
+  print(includeIncomingProperties: boolean = true) {
+    return this.toString();
+  }
+
+  private _equals(other: Term, caseSensitive: boolean = true) {
+    if (other === this) return true;
+
+    var valueToMatch: string;
+    var languageToMatch: string;
+    var datatypeToMatch: NamedNode;
+
+    if (other instanceof Literal) {
+      valueToMatch = other.value;
+      languageToMatch = other.language;
+      datatypeToMatch = other.datatype; //direct access to avoid default, alternatively build a boolean parameter 'returnDefault=true' into getDataType()
+    } else {
+      var type = typeof other;
+      if (type == 'string' || type == 'number' || type == 'boolean') {
+        //if you don't specify a datatype we accept all
+        valueToMatch = other.toString();
+        languageToMatch = '';
+        datatypeToMatch = null;
+      } else {
+        return false;
+      }
+    }
+
+    //do the actual matching
+    var valueMatch: boolean;
+    if (caseSensitive) {
+      valueMatch = this._value === valueToMatch;
+    } else {
+      valueMatch =
+        this._value.toLocaleLowerCase() == valueToMatch.toLocaleLowerCase();
+    }
+
+    //if values match
+    if (valueMatch) {
+      //if there is a language
+      if (this.hasLanguage()) {
+        //then only the languages need to match
+        return this.language == languageToMatch;
+      } else {
+        //no language = datatypes need to match
+        //we check with this.datatype, not this.datatype which can return the default xsd:String
+        //a literal without datatypespecified is however considered different from a a literal with a explicit xsd:String datatype
+        //that is, like some SPARQL quad stores, you should be able to create two otherwise identical (sub&pred) quads for those two literals
+        return this.datatype === datatypeToMatch;
+      }
+    }
+    return false;
+  }
+}
+
+export class Graph implements Term {
+  // private static removedQuadsAlterations: Map<Graph,QuadArray> = new Map();
+  /**
+   * Emitted when changes have been made to this graph. Only emitted when data has actually changed, not just when data is loaded
+   */
+  static CONTENTS_ALTERED = 'CONTENTS_ALTERED';
+  /**
+   * Emitted when the contents of this graph have changed. Can also be due to loading data
+   */
+  static CONTENTS_CHANGED = 'CONTENTS_ALTERED';
+
+  private static graphs: CoreMap<string, Graph> = new CoreMap<string, Graph>();
+  // private static addedQuads: Map<Graph,QuadArray> = new Map();
+  // private static removedQuads: Map<Graph,QuadArray> = new Map();
+  // private static addedQuadsAlterations: Map<Graph,QuadArray> = new Map();
+  termType: string = 'NamedNode';
+  private quads: QuadSet;
+
+  constructor(
+    public value: string,
+    quads?: QuadSet,
+  ) {
+    // super();
+    this._node = NamedNode.getOrCreate(value);
+    this.quads = quads ? quads : new QuadSet();
+  }
+
+  private _node: NamedNode;
+
+  get node(): NamedNode {
+    return this._node;
+  }
+
+  //Static methods
+  /**
+   * Resets the map of nodes that is known in this environment
+   */
+  static reset() {
+    this.graphs = new CoreMap<string, Graph>();
+  }
+
+  static create(quads?: QuadSet): Graph {
+    var uri = NamedNode.createNewTempUri();
+    return this._create(uri, quads);
+  }
+
+  /**
+   * @internal
+   * @param graph
+   */
+  static register(graph: Graph) {
+    if (this.graphs.has(graph.node.uri)) {
+      throw new Error(
+        'A graph with this URI already exists. You should probably use Graph.getOrCreate instead of Graph.create (' +
+          graph.node.uri +
+          ')',
+      );
+    }
+    this.graphs.set(graph.node.uri, graph);
+    // super.register(graph);
+  }
+
+  /**
+   * @internal
+   * @param graph
+   */
+  static unregister(graph: Graph) {
+    if (!this.graphs.has(graph.node.uri)) {
+      throw new Error(
+        'This node has already been removed from the registry: ' +
+          graph.node.uri,
+      );
+    }
+    this.graphs.delete(graph.node.uri);
+  }
+
+  /**
+   * Adds the quad to all given maps
+   * @param quad
+   * @param maps
+   * @private
+   */
+  /*private static registerGraphEvent(graph: Graph, quad:Quad, maps: Map<Graph, QuadArray>[]) {
+    //register that this class has some events to emit
+    eventBatcher.register(Graph);
+    //for each given map
+    maps.forEach((map) => {
+      //add this quad under the predicate as key
+      if (!map.has(graph)) {
+        map.set(graph, new QuadArray());
+      }
+      map.get(graph).push(quad);
+    });
+  }*/
+
+  /*static emitBatchedEvents(resolve?: any, reject?: any) {
+    if(this.addedQuads.size > 0 || this.removedQuads.size > 0)
+    {
+      this.emitter.emit(Graph.CONTENTS_CHANGED,this.addedQuads,this.removedQuads);
+      this.addedQuads = new Map();
+      this.removedQuads = new Map()
+    }
+    if(this.addedQuadsAlterations.size > 0 || this.removedQuadsAlterations.size > 0)
+    {
+      this.emitter.emit(Graph.CONTENTS_ALTERED,this.addedQuadsAlterations,this.removedQuadsAlterations);
+      this.addedQuadsAlterations = new Map();
+      this.removedQuadsAlterations = new Map()
+    }
+  }*/
+
+  static getOrCreate(uri: string) {
+    return this.getGraph(uri) || this._create(uri);
+  }
+
+  static getGraph(uri: string, mustExist: boolean = false): Graph | null {
+    //look it up in known full uri node map
+    if (this.graphs.has(uri)) {
+      return this.graphs.get(uri);
+    }
+
+    if (mustExist) {
+      throw Error('Could not find graph for: ' + uri);
+    }
+    return null;
+  }
+
+  static updateUri(graph: Graph, uri: string) {
+    (graph.node as NamedNode).uri = uri;
+  }
+
+  static getAll(): CoreMap<string, Graph> {
+    return this.graphs;
+  }
+
+  private static _create(uri: string, quads?: QuadSet): Graph {
+    var graph = new Graph(uri, quads);
+    this.register(graph);
+    return graph;
+  }
+
+  equals(other: Term) {
+    return other === this;
+  }
+
+  /**
+   * @internal
+   * @param quad
+   */
+  registerQuad(
+    quad: Quad,
+    alteration: boolean = false,
+    emitEvents: boolean = true,
+  ) {
+    this.quads.add(quad);
+    // if(emitEvents)
+    // {
+    //   Graph.registerGraphEvent(this,quad,alteration ? [Graph.addedQuads] : [Graph.addedQuads,Graph.addedQuadsAlterations]);
+    // }
+  }
+
+  /**
+   * @internal
+   * @param quad
+   */
+  unregisterQuad(
+    quad: Quad,
+    alteration: boolean = false,
+    emitEvents: boolean = true,
+  ) {
+    this.quads.delete(quad);
+    // if(emitEvents)
+    // {
+    //   Graph.registerGraphEvent(this,quad,alteration ? [Graph.removedQuads] : [Graph.removedQuads,Graph.removedQuadsAlterations])
+    // }
+  }
+
+  hasQuad(quad: Quad) {
+    return this.quads.has(quad);
+  }
+
+  //Note: cannot name this getQuads, because NamedNode already uses that for getting all quads of all its properties
+  getContents(): QuadSet {
+    return this.quads;
+  }
+
+  setContents(quads: QuadSet) {
+    this.quads = quads;
+  }
+
+  toString() {
+    return (
+      'Graph: [' +
+      this.node.uri.toString() +
+      ' - ' +
+      this.quads.size +
+      ' quads]'
+    );
+  }
+}
+
+class DefaultGraph extends Graph implements TFDefaultGraph {
+  value: '' = '';
+  termType: typeof DefaultGraphTermType = DefaultGraphTermType;
+
+  uri = defaultGraphURI;
+
+  constructor() {
+    //empty string for default graph URI (part of the standard)
+    //https://rdf.js.org/data-model-spec/#defaultgraph-interface
+    super('');
+  }
+
+  toString() {
+    return 'DefaultGraph';
+  }
+}
+
+export const defaultGraph = new DefaultGraph();
+
+export class Quad extends EventEmitter {
+  /**
+   * Emitter used by the class itself by static methods emitting events.
+   * Anyone wanting to listen to that should therefore add a listener with Quad.emitter.on(...)
+   * @internal
+   */
+  static emitter = new EventEmitter();
+
+  /**
+   * The number of quads active in this system
+   */
+  static globalNumQuads: number = 0;
+  /**
+   * @internal
+   * emitted when new quads have been created
+   * TODO: possibly we can remove this, it may never be used. Only alterations are of interest?
+   */
+  static QUADS_CREATED: string = 'QUADS_CREATED';
+  /**
+   * @internal
+   * emitted by the Quad class itself when quads have been removed
+   * TODO: possibly we can remove this, it may never be used. Only alterations are of interest?
+   */
+  static QUADS_REMOVED: string = 'QUADS_REMOVED';
+  /**
+   * emitted by a quad when that quad is being removed
+   * TODO: possibly we can remove this, it may never be used. Only alterations are of interest?
+   */
+  static QUAD_REMOVED: string = 'QUAD_REMOVED';
+  /**
+   * emitted when quads have been altered by user interaction
+   * @internal
+   */
+  static QUADS_ALTERED: string = 'QUADS_ALTERED';
+  //TODO: possibly we can remove these first two, they may never be used. Only alterations are of interest?
+  private static createdQuads: QuadSet = new QuadSet();
+  private static removedQuads: QuadSet = new QuadSet();
+  private static removedQuadsAltered: QuadSet = new QuadSet();
+  private static createdQuadsAltered: QuadSet = new QuadSet();
+  private _removed: boolean;
+
+  /**
+   * Creates the quad
+   * @param subject - the subject of the quad
+   * @param predicate
+   * @param object
+   */
+  constructor(
+    public subject: NamedNode,
+    public predicate: NamedNode,
+    public object: Node,
+    private _graph: Graph = defaultGraph,
+    public implicit: boolean = false,
+    alteration: boolean = false,
+    emitEvents: boolean = true,
+  ) {
+    super();
+    this.setup(alteration, emitEvents);
+  }
+
+  get graph() {
+    return this._graph;
+  }
+
+  /**
+   * Returns true if this quad still exists as an object in memory, but is no longer actively used in the graph
+   */
+  get isRemoved(): boolean {
+    return this._removed;
+  }
+
+  /**
+   * @internal
+   * Returns true if events of newly created quads or removed quads are currently batched and waiting to be emitted
+   */
+  static hasBatchedEvents() {
+    return this.createdQuads.size > 0 || this.removedQuads.size > 0;
+  }
+
+  /*set graph(newGraph: Graph) {
+    if(newGraph !== this._graph)
+    {
+      //NOTE: we could have gone a different way with Quad.moveToGraph(quad,newGraph) / quad.moveto(newGraph), which removes the old one and returns a new quad
+      //if there is any issues with this implementation, go that way.
+      //for now, this implementation keeps the same Quad object but mimics the adding / removing of quads
+
+      //create a clone of this quad as it is now, without sending alteration events
+      let oldQuad = new Quad(this.subject,this.predicate,this.object,this._graph,this.implicit,false,false);
+
+      //make sure this cloned quad is not even registered
+      oldQuad.turnOff();
+
+      //remove this quad from the old graph
+      this._graph.unregisterQuad(this,true);
+
+      //update the graph
+      this._graph = newGraph;
+
+      //register this quad in the new graph
+      this._graph.registerQuad(this,true);
+
+      this.mimicEventsOnUpdate(oldQuad);
+    }
+	}*/
+
+  /**
+   * @internal
+   */
+  static emitBatchedEvents() {
+    if (this.createdQuads.size > 0 && this.removedQuads.size > 0) {
+      //if both created and removed quads are batched then we remove the quad from both sets
+      this.createdQuads.forEach((quad) => {
+        if (this.removedQuads.has(quad)) {
+          this.createdQuads.delete(quad);
+          this.removedQuads.delete(quad);
+        }
+      });
+    }
+    if (this.createdQuads.size > 0) {
+      this.emitter.emit(Quad.QUADS_CREATED, this.createdQuads);
+      this.createdQuads = new QuadSet();
+    }
+    if (this.removedQuads.size > 0) {
+      this.emitter.emit(Quad.QUADS_REMOVED, this.removedQuads);
+      this.removedQuads = new QuadSet();
+    }
+    if (
+      this.createdQuadsAltered.size > 0 ||
+      this.removedQuadsAltered.size > 0
+    ) {
+      this.emitter.emit(
+        Quad.QUADS_ALTERED,
+        this.createdQuadsAltered,
+        this.removedQuadsAltered,
+      );
+      this.createdQuadsAltered = new QuadSet();
+      this.removedQuadsAltered = new QuadSet();
+    }
+  }
+
+  /**
+   * Get the existing quad for the given subject,predicate and object, or create it if it didn't exists yet.
+   * @param subject
+   * @param predicate
+   * @param object
+   * @param implicit
+   * @param alteration - states whether this quad has been created by a user interaction (true) or simply because of updated data has been loaded
+   */
+  static getOrCreate(
+    subject: NamedNode,
+    predicate: NamedNode,
+    object: Node,
+    graph: Graph = defaultGraph,
+    implicit: boolean = false,
+    alteration: boolean = false,
+    emitEvents: boolean = true,
+  ) {
+    return (
+      this.get(subject, predicate, object, graph) ||
+      new Quad(
+        subject,
+        predicate,
+        object,
+        graph,
+        implicit,
+        alteration,
+        emitEvents,
+      )
+    );
+  }
+
+  /**
+   * Gets the existing quad for the given subject,predicate and object.
+   * Will return any quad with an equivalent object. See Literal.isEquivalentTo() and NamedNode.isEquivalentTo() for more information.
+   * @param subject
+   * @param predicate
+   * @param object
+   */
+  static get(
+    subject: NamedNode,
+    predicate: NamedNode,
+    object: Node,
+    graph: Graph,
+  ): Quad | null {
+    if (!subject || !predicate || !object) return null;
+    return subject.getQuads(predicate, object).find((q) => q._graph === graph);
+  }
+
+  static moveQuadsToGraph(
+    quads: Quad[],
+    graph: Graph,
+    alteration: boolean = false,
+  ) {
+    let result = new (Object.getPrototypeOf(quads).constructor)();
+    quads.forEach((quad) => {
+      result.push(quad.moveToGraph(graph, alteration));
+    });
+    return result;
+  }
+
+  static emitRemovedQuad(quad: Quad, alteration: boolean = false) {
+    //removed quad events are batched together and emitted on the next tick
+    //so here we make sure the Quad class will emit its batched events on the next tick
+    eventBatcher.register(Quad);
+    //and here we save this quad to a set of removedQuads which is a static property of the Quad class
+    Quad.removedQuads.add(quad);
+
+    if (alteration && !quad.implicit) {
+      Quad.removedQuadsAltered.add(quad);
+    }
+
+    //we need to let this quad emit this event straight away because for example the reasoner needs to listen to this exact quad to retract
+    quad.emit(Quad.QUAD_REMOVED);
+  }
+
+  static emitCreatedQuad(quad: Quad, alteration: boolean = false) {
+    //new quad events are batched together and emitted on the next tick
+    //so here we make sure the Quad class will emit its batched events on the next tick
+    eventBatcher.register(Quad);
+    //and here we save this quad to a set of newQuads which is a static property of the Quad class
+    Quad.createdQuads.add(quad);
+
+    //only if it's an alteration AND it's relevant to storage controllers do we emit the QUADS_ALTERED event for this quad
+    if (alteration && !quad.implicit) {
+      Quad.createdQuadsAltered.add(quad);
+    }
+  }
+
+  /**
+   * Removes this quad and creates a new quad with the same subject,predicate,object, but a new graph.
+   * Returns the new quad
+   * @param newGraph
+   */
+  moveToGraph(newGraph: Graph, alteration: boolean = true): Quad {
+    if (newGraph === this._graph) {
+      return this;
+    }
+    let newQuad = Quad.getOrCreate(
+      this.subject,
+      this.predicate,
+      this.object,
+      newGraph,
+      this.implicit,
+      alteration,
+    );
+    this.remove(alteration);
+    return newQuad;
+  }
+
+  /**
+   * Turns off a quad. Meaning it will no longer be active in the graph.
+   * Comes in handy in very specific use cases when for example quads have already been created, but you want to check what the state was before these quads were created
+   */
+  turnOff() {
+    this.subject.unregisterProperty(this, false, false);
+    // this.predicate.unregisterAsPredicate(this, false, false);
+    this.object.unregisterInverseProperty(this, false, false);
+    this.graph.unregisterQuad(this, false, false);
+  }
+
+  /**
+   * Turns on a quad. Meaning it will be active (again) in the graph.
+   * Only use this if you've had to turn quads off first.
+   */
+  turnOn() {
+    this.subject.registerProperty(this, false, false);
+    // this.predicate.registerAsPredicate(this, false, false);
+    this.object.registerInverseProperty(this, false, false);
+    this.graph.registerQuad(this, false, false);
+  }
+
+  /**
+   * Turn an implicit quad into an explicit quad (because an explicit user action generated it as an independent explicit fact now)
+   */
+  makeExplicit() {
+    if (this.implicit) {
+      //unregister and make explicit
+      this.turnOff();
+      this.implicit = false;
+      //re-register and make it an 'alteration' so it will be picked up by the storage
+      this.setup(true);
+    }
+  }
+
+  /**
+   * Remove this quad from the graph
+   * Will be removed both locally and from the graph database
+   * @param alteration
+   */
+  remove(alteration: boolean = false, emitEvents: boolean = true): void {
+    if (this._removed) return;
+
+    //first set removed is true so event handlers can detect the difference between added or removed values
+    this._removed = true;
+
+    this.subject.unregisterProperty(this);
+    // this.predicate.unregisterAsPredicate(this);
+    this.object.unregisterInverseProperty(this);
+    this.graph.unregisterQuad(this, alteration);
+
+    if (emitEvents) {
+      Quad.emitRemovedQuad(this, alteration);
+    }
+
+    Quad.globalNumQuads--;
+  }
+
+  /**
+   * Cancel the removal of a quad
+   */
+  undoRemoval() {
+    this.setup();
+    this._removed = false;
+  }
+
+  onValueChanged(oldValue: Literal) {
+    let oldQuad = new Quad(
+      this.subject,
+      this.predicate,
+      oldValue,
+      this.graph,
+      this.implicit,
+      false,
+      false,
+    );
+    this.mimicEventsOnUpdate(oldQuad);
+  }
+
+  print() {
+    return (
+      Prefix.toPrefixedIfPossible(this.subject.uri) +
+      ' ' +
+      Prefix.toPrefixedIfPossible(this.predicate.uri) +
+      ' ' +
+      (this.object instanceof NamedNode
+        ? Prefix.toPrefixedIfPossible(this.object.uri)
+        : this.object.toString())
+    );
+  }
+
+  /**
+   * Print this quad as a string
+   */
+  toString() {
+    return (
+      this.subject.toString() +
+      ' ' +
+      this.predicate.toString() +
+      ' ' +
+      this.object.toString() +
+      ' ' +
+      this.graph.toString() +
+      (this.isRemoved ? ' (removed)' : '')
+    );
+  }
+
+  private setup(alteration: boolean = false, emitEvents: boolean = true) {
+    // if(this.predicate.uri == "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" && this.object['uri'] == "http://data.dacore.org/ontologies/core/Editor")
+    // {
+    // 	debugger;
+    // }
+
+    //let nodes take note of this quad in which they occur
+    //first, we overwrite the property this.object with the result of register because a Literal may return a clone
+    this.object = this.object.registerInverseProperty(this, alteration);
+    this.subject.registerProperty(this, alteration);
+    // this.predicate.registerAsPredicate(this, alteration);
+    this._graph.registerQuad(this, alteration);
+
+    if (emitEvents) {
+      Quad.emitCreatedQuad(this, alteration);
+    }
+    Quad.globalNumQuads++;
+  }
+
+  private mimicEventsOnUpdate(oldQuad: Quad) {
+    //manually mimic the fact the old quad was removed and the new quad was added (storage requires this to add/remove those quads to/from the right quad stores)
+    eventBatcher.register(Quad);
+    Quad.removedQuads.add(oldQuad);
+    Quad.removedQuadsAltered.add(oldQuad);
+
+    Quad.createdQuads.add(this);
+    Quad.createdQuadsAltered.add(this);
+  }
+}
+
+//for debugging purposes
+let getNode = function (uri: string) {
+  return NamedNode.getOrCreate(uri);
+};
+if (typeof window !== 'undefined') {
+  window['getNode'] = getNode;
+} else if (typeof global !== 'undefined') {
+  global['getNode'] = getNode;
+}

--- a/rebrand/linked-mem-store/src/ontologies/rdf.ts
+++ b/rebrand/linked-mem-store/src/ontologies/rdf.ts
@@ -1,0 +1,30 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+import {NamedNode} from '../models.js';
+import {Prefix} from '../utils/Prefix.js';
+
+var base: string = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#';
+export var _ontologyResource: NamedNode = NamedNode.getOrCreate(base);
+Prefix.add('rdf', base);
+
+var langString: NamedNode = NamedNode.getOrCreate(base + 'langString');
+var type: NamedNode = NamedNode.getOrCreate(base + 'type');
+var Property: NamedNode = NamedNode.getOrCreate(base + 'Property');
+var List: NamedNode = NamedNode.getOrCreate(base + 'List');
+var rest: NamedNode = NamedNode.getOrCreate(base + 'rest');
+var first: NamedNode = NamedNode.getOrCreate(base + 'first');
+var nil: NamedNode = NamedNode.getOrCreate(base + 'nil');
+
+export const rdf = {
+  _ontologyResource,
+  langString,
+  type,
+  Property,
+  List,
+  rest,
+  first,
+  nil,
+};

--- a/rebrand/linked-mem-store/src/ontologies/xsd.ts
+++ b/rebrand/linked-mem-store/src/ontologies/xsd.ts
@@ -1,0 +1,45 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+import {NamedNode} from '../models.js';
+import {Prefix} from '../utils/Prefix.js';
+
+var base: string = 'http://www.w3.org/2001/XMLSchema#';
+export var _ontologyResource: NamedNode = NamedNode.getOrCreate(base);
+Prefix.add('xsd', base);
+
+var string: NamedNode = NamedNode.getOrCreate(base + 'string');
+var boolean: NamedNode = NamedNode.getOrCreate(base + 'boolean');
+var date: NamedNode = NamedNode.getOrCreate(base + 'date');
+var integer: NamedNode = NamedNode.getOrCreate(base + 'integer');
+var float: NamedNode = NamedNode.getOrCreate(base + 'float');
+var double: NamedNode = NamedNode.getOrCreate(base + 'double');
+var time: NamedNode = NamedNode.getOrCreate(base + 'time');
+var duration: NamedNode = NamedNode.getOrCreate(base + 'duration');
+var decimal: NamedNode = NamedNode.getOrCreate(base + 'decimal');
+var gYear: NamedNode = NamedNode.getOrCreate(base + 'gYear');
+var Bytes: NamedNode = NamedNode.getOrCreate(base + 'Bytes');
+var long: NamedNode = NamedNode.getOrCreate(base + 'long');
+var dateTime: NamedNode = NamedNode.getOrCreate(base + 'dateTime');
+
+//not yet required by core so why define it?
+//export var boolean:NamedNode = nodes.getOrCreate(base+"boolean");
+
+export const xsd = {
+  _ontologyResource,
+  string,
+  boolean,
+  date,
+  integer,
+  float,
+  double,
+  time,
+  duration,
+  decimal,
+  gYear,
+  Bytes,
+  long,
+  dateTime,
+};

--- a/rebrand/linked-mem-store/src/stores/InMemoryStore.ts
+++ b/rebrand/linked-mem-store/src/stores/InMemoryStore.ts
@@ -1,0 +1,188 @@
+import type {CreateQuery} from 'linked-js/queries/CreateQuery.js';
+import type {DeleteQuery} from 'linked-js/queries/DeleteQuery.js';
+import type {SelectQuery} from 'linked-js/queries/SelectQuery.js';
+import type {UpdateQuery} from 'linked-js/queries/UpdateQuery.js';
+import {Graph, NamedNode, Quad} from '../models.js';
+import {QuadSet} from '../collections/QuadSet.js';
+import {QuadArray} from '../collections/QuadArray.js';
+import type {ICoreIterable} from '../interfaces/ICoreIterable.js';
+import type {NodeSet} from '../collections/NodeSet.js';
+import type {CoreMap} from '../collections/CoreMap.js';
+import type {IQuadStore} from '../interfaces/IQuadStore.js';
+import {createLocal, deleteLocal, resolveLocal, updateLocal} from '../utils/LocalQueryResolver.js';
+
+export class InMemoryStore implements IQuadStore {
+  /**
+   * You can use this to define (overwrite) which graph this store uses for its quads
+   */
+  public targetGraph: Graph;
+  protected contents: QuadSet;
+  private initPromise: Promise<any> | null = null;
+  public namedNode: NamedNode;
+
+  constructor(uri?: string) {
+    this.namedNode = uri ? NamedNode.getOrCreate(uri) : NamedNode.create();
+  }
+
+  init(): Promise<any> {
+    if (!this.initPromise) {
+      this.initPromise = this.loadContents();
+    }
+    return this.initPromise;
+  }
+
+  loadContents(): Promise<QuadSet> {
+    this.contents = new QuadSet();
+    return Promise.resolve(this.contents);
+  }
+
+  /**
+   * returns the contents of the InMemoryStore as a QuadSet
+   * do NOT modify the returned QuadSet directly. Add or remove contents to this store instead
+   */
+  getContents(): QuadSet {
+    return this.contents;
+  }
+
+  updateQuery<RType>(query: UpdateQuery<RType>): Promise<RType> {
+    return Promise.resolve(updateLocal(query));
+  }
+
+  createQuery<R>(query: CreateQuery<R>): Promise<R> {
+    return Promise.resolve(createLocal(query));
+  }
+
+  deleteQuery(query: DeleteQuery): Promise<unknown> {
+    return Promise.resolve(deleteLocal(query));
+  }
+
+  selectQuery<ResultType>(query: SelectQuery): Promise<ResultType> {
+    return Promise.resolve(resolveLocal(query)) as Promise<ResultType>;
+  }
+
+  /** @deprecated Legacy quad-level API. */
+  update(
+    toAdd: ICoreIterable<Quad>,
+    toRemove: ICoreIterable<Quad>,
+  ): Promise<any> {
+    return this.init().then(() => {
+      if (toAdd) {
+        this._addMultiple(toAdd);
+      }
+      if (toRemove) {
+        this._deleteMultiple(toRemove as QuadArray);
+      }
+      return this.onContentsUpdated();
+    });
+  }
+
+  /** @deprecated Legacy quad-level API. */
+  getDefaultGraph(): Graph {
+    return Graph.getOrCreate(this.namedNode.uri);
+  }
+
+  /** @deprecated Legacy quad-level API. */
+  add(quad: Quad): Promise<any> {
+    return this.init().then(() => {
+      this.addNewContents(new QuadArray(quad));
+      this.onContentsUpdated();
+      return true;
+    });
+  }
+
+  /** @deprecated Legacy quad-level API. */
+  addMultiple(quads: QuadSet): Promise<any> {
+    return this.init().then(() => {
+      this._addMultiple(quads);
+      this.onContentsUpdated();
+      return true;
+    });
+  }
+
+  /** @deprecated Legacy quad-level API. */
+  delete(quad: Quad): Promise<any> {
+    return this.init().then(() => {
+      this._deleteMultiple(new QuadArray(quad));
+      this.onContentsUpdated();
+      return true;
+    });
+  }
+
+  /** @deprecated Legacy quad-level API. */
+  deleteMultiple(quads: QuadSet): Promise<any> {
+    return this.init().then(() => {
+      this._deleteMultiple(quads);
+      this.onContentsUpdated();
+      return true;
+    });
+  }
+
+  /** @deprecated Legacy quad-level API. */
+  clearProperties(
+    subjectToPredicates: CoreMap<NamedNode, NodeSet<NamedNode>>,
+  ): Promise<boolean> {
+    return this.init().then(() => {
+      const toDelete = new QuadSet();
+      this.contents.forEach((q) => {
+        if (
+          subjectToPredicates.has(q.subject) &&
+          subjectToPredicates.get(q.subject).has(q.predicate)
+        ) {
+          toDelete.add(q);
+        }
+      });
+      if (toDelete.size > 0) {
+        return this.deleteMultiple(toDelete);
+      }
+      return false;
+    });
+  }
+
+  /** @deprecated Legacy URI management API. */
+  setURIs(
+    _nodeToCurrentUriMap: CoreMap<NamedNode, string>,
+  ): Promise<[string, string][]> {
+    return Promise.resolve([]);
+  }
+
+  /** @deprecated Legacy cleanup API. */
+  removeNodes(_nodes: ICoreIterable<NamedNode>): Promise<any> {
+    return Promise.resolve(true);
+  }
+
+  /** @deprecated Legacy load API. */
+  loadShape(_shapeInstance: any, _request: any): Promise<QuadArray> {
+    return this.init().then(() => new QuadArray());
+  }
+
+  /** @deprecated Legacy load API. */
+  loadShapes(_shapeInstances: any, _request: any): Promise<QuadArray> {
+    return this.init().then(() => new QuadArray());
+  }
+
+  protected onContentsUpdated(): Promise<boolean> {
+    return Promise.resolve(false);
+  }
+
+  protected addNewContents(quads: QuadArray | QuadSet) {
+    const graph = this.getDefaultGraph();
+    const toAdd =
+      quads instanceof QuadArray ? quads : new QuadArray(...Array.from(quads));
+    toAdd.forEach((quad) => {
+      this.contents.add(quad.moveToGraph(graph));
+    });
+  }
+
+  protected _addMultiple(quads: ICoreIterable<Quad>) {
+    const graph = this.getDefaultGraph();
+    for (const quad of quads) {
+      this.contents.add(quad.moveToGraph(graph));
+    }
+  }
+
+  protected _deleteMultiple(quads: ICoreIterable<Quad>) {
+    for (const quad of quads) {
+      this.contents.delete(quad);
+    }
+  }
+}

--- a/rebrand/linked-mem-store/src/stores/InMemoryStore.ts
+++ b/rebrand/linked-mem-store/src/stores/InMemoryStore.ts
@@ -52,8 +52,8 @@ export class InMemoryStore implements IQuadStore {
     return Promise.resolve(createLocal(query));
   }
 
-  deleteQuery(query: DeleteQuery): Promise<unknown> {
-    return Promise.resolve(deleteLocal(query));
+  deleteQuery<ResultType>(query: DeleteQuery): Promise<ResultType> {
+    return Promise.resolve(deleteLocal(query) as ResultType);
   }
 
   selectQuery<ResultType>(query: SelectQuery): Promise<ResultType> {

--- a/rebrand/linked-mem-store/src/tests/models.test.ts
+++ b/rebrand/linked-mem-store/src/tests/models.test.ts
@@ -1,0 +1,37 @@
+import {describe, expect, test} from '@jest/globals';
+import {Graph, Literal, NamedNode, Quad} from '../models.js';
+import {QuadSet} from '../collections/QuadSet.js';
+
+const subjectUri = 'https://example.com/subject';
+const predicateUri = 'https://example.com/predicate';
+
+describe('RDF models', () => {
+  test('NamedNode.getOrCreate returns stable instances', () => {
+    const first = NamedNode.getOrCreate(subjectUri);
+    const second = NamedNode.getOrCreate(subjectUri);
+
+    expect(first).toBe(second);
+    expect(first.uri).toBe(subjectUri);
+  });
+
+  test('Graph.getOrCreate returns stable instances', () => {
+    const first = Graph.getOrCreate('https://example.com/graph');
+    const second = Graph.getOrCreate('https://example.com/graph');
+
+    expect(first).toBe(second);
+    expect(first.value).toBe('https://example.com/graph');
+  });
+
+  test('QuadSet tracks subjects and objects', () => {
+    const subject = NamedNode.getOrCreate(subjectUri);
+    const predicate = NamedNode.getOrCreate(predicateUri);
+    const object = new Literal('value');
+    const quad = new Quad(subject, predicate, object);
+
+    const set = new QuadSet();
+    set.add(quad);
+
+    expect(set.getSubjects().has(subject)).toBe(true);
+    expect(set.getObjects().has(object)).toBe(true);
+  });
+});

--- a/rebrand/linked-mem-store/src/tests/query-basic.test.ts
+++ b/rebrand/linked-mem-store/src/tests/query-basic.test.ts
@@ -58,11 +58,13 @@ const seedPeople = () => {
 };
 
 describe('query results - basic property selection', () => {
+  let people: ReturnType<typeof seedPeople>;
+
   beforeEach(() => {
     resetLocalStore();
     LinkedStorage.reset();
     LinkedStorage.setDefaultStore(new InMemoryStore());
-    seedPeople();
+    people = seedPeople();
   });
 
   test('can select a literal property of all instances', async () => {
@@ -71,11 +73,13 @@ describe('query results - basic property selection', () => {
       name: string;
     }>;
     const p1 = names.find((person) => person.name === 'Semmy');
+    const firstName: string = names[0].name;
 
     expect(Array.isArray(names)).toBe(true);
     expect(names.length).toBe(4);
+    expect(firstName).toBeDefined();
     expect(p1?.name).toBe('Semmy');
-    expect(p1?.id).toBe(NamedNode.TEMP_URI_BASE + 'p1-semmy');
+    expect(p1?.id).toBe(people.p1.uri);
   });
 
   test('can select an object property of all instances', async () => {
@@ -84,14 +88,16 @@ describe('query results - basic property selection', () => {
       friends: Array<{id: string}>;
     }>;
     const firstResult = personFriends.find(
-      (person) => person.id === NamedNode.TEMP_URI_BASE + 'p1-semmy',
+      (person) => person.id === people.p1.uri,
     );
+    const firstFriendId: string = personFriends[0].friends[0].id;
 
     expect(Array.isArray(personFriends)).toBe(true);
     expect(personFriends.length).toBe(4);
+    expect(firstFriendId).toBeDefined();
     expect(firstResult?.friends.length).toBe(2);
-    expect(firstResult?.friends[0].id).toBe(NamedNode.TEMP_URI_BASE + 'p2-moa');
-    expect(firstResult?.friends[1].id).toBe(NamedNode.TEMP_URI_BASE + 'p3-jinx');
+    expect(firstResult?.friends[0].id).toBe(people.p2.uri);
+    expect(firstResult?.friends[1].id).toBe(people.p3.uri);
   });
 
   test('can select a date', async () => {
@@ -100,11 +106,13 @@ describe('query results - basic property selection', () => {
       p.name,
     ])) as Array<{id: string; birthDate: Date; name: string}>;
     const firstResult = birthDates.find(
-      (person) => person.id === NamedNode.TEMP_URI_BASE + 'p1-semmy',
+      (person) => person.id === people.p1.uri,
     );
+    const firstDate: Date = birthDates[0].birthDate;
 
     expect(Array.isArray(birthDates)).toBe(true);
     expect(birthDates.length).toBe(4);
+    expect(firstDate).toBeDefined();
     expect(firstResult?.birthDate instanceof Date).toBe(true);
     expect(firstResult?.birthDate.toISOString()).toBe(
       new Date('1990-01-01').toISOString(),
@@ -117,30 +125,34 @@ describe('query results - basic property selection', () => {
       isRealPerson: boolean | null;
     }>;
     const p1 = isRealPersons.find(
-      (person) => person.id === NamedNode.TEMP_URI_BASE + 'p1-semmy',
+      (person) => person.id === people.p1.uri,
     );
     const p2 = isRealPersons.find(
-      (person) => person.id === NamedNode.TEMP_URI_BASE + 'p2-moa',
+      (person) => person.id === people.p2.uri,
     );
     const p4 = isRealPersons.find(
-      (person) => person.id === NamedNode.TEMP_URI_BASE + 'p4-quinn',
+      (person) => person.id === people.p4.uri,
     );
+    const firstFlag: boolean | null = isRealPersons[0].isRealPerson;
 
     expect(Array.isArray(isRealPersons)).toBe(true);
     expect(isRealPersons.length).toBe(4);
+    expect(firstFlag).toBeDefined();
     expect(p1?.isRealPerson).toBe(true);
     expect(p2?.isRealPerson).toBe(false);
     expect(p4?.isRealPerson).toBeNull();
   });
 
   test('can select properties of a specific subject', async () => {
-    const id = NamedNode.TEMP_URI_BASE + 'p1-semmy';
+    const id = people.p1.uri;
     const qRes = (await Person.select({id}, (p) => p.name)) as {
       id: string;
       name: string;
     };
+    const selectedName: string = qRes.name;
     expect(qRes.name).toBe('Semmy');
     expect(qRes.id).toBe(id);
+    expect(selectedName).toBeDefined();
   });
 
   test('select with a non existing returns undefined', async () => {
@@ -154,15 +166,18 @@ describe('query results - basic property selection', () => {
 
   test('selecting only undefined properties returns an empty object', async () => {
     const qRes = (await Person.select(
-      {id: NamedNode.TEMP_URI_BASE + 'p3-jinx'},
+      {id: people.p3.uri},
       (p) => [p.hobby, p.bestFriend],
     )) as {
       id: string;
       hobby: string | null;
       bestFriend: {id: string} | null;
     };
+    const bestFriendId: string | null =
+      qRes.bestFriend?.id ?? null;
     expect(qRes.hobby).toBeNull();
     expect(qRes.bestFriend).toBeNull();
-    expect(qRes.id).toBe(NamedNode.TEMP_URI_BASE + 'p3-jinx');
+    expect(qRes.id).toBe(people.p3.uri);
+    expect(bestFriendId).toBeNull();
   });
 });

--- a/rebrand/linked-mem-store/src/tests/query-basic.test.ts
+++ b/rebrand/linked-mem-store/src/tests/query-basic.test.ts
@@ -68,10 +68,7 @@ describe('query results - basic property selection', () => {
   });
 
   test('can select a literal property of all instances', async () => {
-    const names = (await Person.select((p) => p.name)) as Array<{
-      id: string;
-      name: string;
-    }>;
+    const names = await Person.select((p) => p.name);
     const p1 = names.find((person) => person.name === 'Semmy');
     const firstName: string = names[0].name;
 
@@ -120,10 +117,7 @@ describe('query results - basic property selection', () => {
   });
 
   test('can select a boolean', async () => {
-    const isRealPersons = (await Person.select((p) => p.isRealPerson)) as Array<{
-      id: string;
-      isRealPerson: boolean | null;
-    }>;
+    const isRealPersons = await Person.select((p) => p.isRealPerson);
     const p1 = isRealPersons.find(
       (person) => person.id === people.p1.uri,
     );
@@ -145,10 +139,7 @@ describe('query results - basic property selection', () => {
 
   test('can select properties of a specific subject', async () => {
     const id = people.p1.uri;
-    const qRes = (await Person.select({id}, (p) => p.name)) as {
-      id: string;
-      name: string;
-    };
+    const qRes = await Person.select({id}, (p) => p.name);
     const selectedName: string = qRes.name;
     expect(qRes.name).toBe('Semmy');
     expect(qRes.id).toBe(id);
@@ -156,10 +147,10 @@ describe('query results - basic property selection', () => {
   });
 
   test('select with a non existing returns undefined', async () => {
-    const qRes = (await Person.select(
+    const qRes = await Person.select(
       {id: 'https://does.not/exist'},
       (p) => p.name,
-    )) as {id: string; name: string} | undefined;
+    );
     expect(qRes).toBeUndefined();
     expect(NamedNode.getNamedNode('https://does.not/exist')).toBeUndefined();
   });
@@ -168,11 +159,7 @@ describe('query results - basic property selection', () => {
     const qRes = (await Person.select(
       {id: people.p3.uri},
       (p) => [p.hobby, p.bestFriend],
-    )) as {
-      id: string;
-      hobby: string | null;
-      bestFriend: {id: string} | null;
-    };
+    )) as {id: string; hobby: string | null; bestFriend: {id: string} | null};
     const bestFriendId: string | null =
       qRes.bestFriend?.id ?? null;
     expect(qRes.hobby).toBeNull();

--- a/rebrand/linked-mem-store/src/tests/query-basic.test.ts
+++ b/rebrand/linked-mem-store/src/tests/query-basic.test.ts
@@ -1,0 +1,168 @@
+import {beforeEach, describe, expect, test} from '@jest/globals';
+import {LinkedStorage} from 'linked-js/utils/LinkedStorage.js';
+import {queryTestFixtures} from 'linked-js';
+import {InMemoryStore} from '../stores/InMemoryStore.js';
+import {NamedNode, Literal} from '../models.js';
+import {rdf} from '../ontologies/rdf.js';
+import {xsd} from '../ontologies/xsd.js';
+import {resetLocalStore} from '../utils/LocalQueryResolver.js';
+
+const {
+  Person,
+  name,
+  bestFriend,
+  friends,
+  hobby,
+  birthDate,
+  isRealPerson,
+  personClass,
+} = queryTestFixtures;
+
+const seedPeople = () => {
+  const base = NamedNode.TEMP_URI_BASE;
+  const p1 = NamedNode.getOrCreate(`${base}p1-semmy`);
+  const p2 = NamedNode.getOrCreate(`${base}p2-moa`);
+  const p3 = NamedNode.getOrCreate(`${base}p3-jinx`);
+  const p4 = NamedNode.getOrCreate(`${base}p4-quinn`);
+
+  const nameNode = NamedNode.getOrCreate(name);
+  const bestFriendNode = NamedNode.getOrCreate(bestFriend);
+  const friendsNode = NamedNode.getOrCreate(friends);
+  const hobbyNode = NamedNode.getOrCreate(hobby);
+  const birthDateNode = NamedNode.getOrCreate(birthDate);
+  const isRealPersonNode = NamedNode.getOrCreate(isRealPerson);
+  const personType = NamedNode.getOrCreate(personClass);
+
+  [p1, p2, p3, p4].forEach((person) => person.set(rdf.type, personType));
+
+  p1.set(nameNode, new Literal('Semmy'));
+  p1.set(birthDateNode, new Literal(new Date('1990-01-01').toISOString(), xsd.dateTime));
+  p1.set(isRealPersonNode, new Literal('true', xsd.boolean));
+
+  p2.set(nameNode, new Literal('Moa'));
+  p2.set(hobbyNode, new Literal('Jogging'));
+  p2.set(isRealPersonNode, new Literal('false', xsd.boolean));
+
+  p3.set(nameNode, new Literal('Jinx'));
+  p3.set(isRealPersonNode, new Literal('true', xsd.boolean));
+
+  p4.set(nameNode, new Literal('Quinn'));
+
+  p1.set(friendsNode, p2);
+  p1.set(friendsNode, p3);
+  p2.set(bestFriendNode, p3);
+  p2.set(friendsNode, p3);
+  p2.set(friendsNode, p4);
+
+  return {p1, p2, p3, p4};
+};
+
+describe('query results - basic property selection', () => {
+  beforeEach(() => {
+    resetLocalStore();
+    LinkedStorage.reset();
+    LinkedStorage.setDefaultStore(new InMemoryStore());
+    seedPeople();
+  });
+
+  test('can select a literal property of all instances', async () => {
+    const names = (await Person.select((p) => p.name)) as Array<{
+      id: string;
+      name: string;
+    }>;
+    const p1 = names.find((person) => person.name === 'Semmy');
+
+    expect(Array.isArray(names)).toBe(true);
+    expect(names.length).toBe(4);
+    expect(p1?.name).toBe('Semmy');
+    expect(p1?.id).toBe(NamedNode.TEMP_URI_BASE + 'p1-semmy');
+  });
+
+  test('can select an object property of all instances', async () => {
+    const personFriends = (await Person.select((p) => p.friends)) as Array<{
+      id: string;
+      friends: Array<{id: string}>;
+    }>;
+    const firstResult = personFriends.find(
+      (person) => person.id === NamedNode.TEMP_URI_BASE + 'p1-semmy',
+    );
+
+    expect(Array.isArray(personFriends)).toBe(true);
+    expect(personFriends.length).toBe(4);
+    expect(firstResult?.friends.length).toBe(2);
+    expect(firstResult?.friends[0].id).toBe(NamedNode.TEMP_URI_BASE + 'p2-moa');
+    expect(firstResult?.friends[1].id).toBe(NamedNode.TEMP_URI_BASE + 'p3-jinx');
+  });
+
+  test('can select a date', async () => {
+    const birthDates = (await Person.select((p) => [
+      p.birthDate,
+      p.name,
+    ])) as Array<{id: string; birthDate: Date; name: string}>;
+    const firstResult = birthDates.find(
+      (person) => person.id === NamedNode.TEMP_URI_BASE + 'p1-semmy',
+    );
+
+    expect(Array.isArray(birthDates)).toBe(true);
+    expect(birthDates.length).toBe(4);
+    expect(firstResult?.birthDate instanceof Date).toBe(true);
+    expect(firstResult?.birthDate.toISOString()).toBe(
+      new Date('1990-01-01').toISOString(),
+    );
+  });
+
+  test('can select a boolean', async () => {
+    const isRealPersons = (await Person.select((p) => p.isRealPerson)) as Array<{
+      id: string;
+      isRealPerson: boolean | null;
+    }>;
+    const p1 = isRealPersons.find(
+      (person) => person.id === NamedNode.TEMP_URI_BASE + 'p1-semmy',
+    );
+    const p2 = isRealPersons.find(
+      (person) => person.id === NamedNode.TEMP_URI_BASE + 'p2-moa',
+    );
+    const p4 = isRealPersons.find(
+      (person) => person.id === NamedNode.TEMP_URI_BASE + 'p4-quinn',
+    );
+
+    expect(Array.isArray(isRealPersons)).toBe(true);
+    expect(isRealPersons.length).toBe(4);
+    expect(p1?.isRealPerson).toBe(true);
+    expect(p2?.isRealPerson).toBe(false);
+    expect(p4?.isRealPerson).toBeNull();
+  });
+
+  test('can select properties of a specific subject', async () => {
+    const id = NamedNode.TEMP_URI_BASE + 'p1-semmy';
+    const qRes = (await Person.select({id}, (p) => p.name)) as {
+      id: string;
+      name: string;
+    };
+    expect(qRes.name).toBe('Semmy');
+    expect(qRes.id).toBe(id);
+  });
+
+  test('select with a non existing returns undefined', async () => {
+    const qRes = (await Person.select(
+      {id: 'https://does.not/exist'},
+      (p) => p.name,
+    )) as {id: string; name: string} | undefined;
+    expect(qRes).toBeUndefined();
+    expect(NamedNode.getNamedNode('https://does.not/exist')).toBeUndefined();
+  });
+
+  test('selecting only undefined properties returns an empty object', async () => {
+    const qRes = (await Person.select(
+      {id: NamedNode.TEMP_URI_BASE + 'p3-jinx'},
+      (p) => [p.hobby, p.bestFriend],
+    )) as {
+      id: string;
+      hobby: string | null;
+      bestFriend: {id: string} | null;
+    };
+    expect(qRes.hobby).toBeNull();
+    expect(qRes.bestFriend).toBeNull();
+    expect(qRes.id).toBe(NamedNode.TEMP_URI_BASE + 'p3-jinx');
+  });
+});

--- a/rebrand/linked-mem-store/src/tests/store.test.ts
+++ b/rebrand/linked-mem-store/src/tests/store.test.ts
@@ -1,0 +1,49 @@
+import {describe, expect, test} from '@jest/globals';
+import {linkedShape, literalProperty, Shape} from 'linked-js';
+import {CreateQueryFactory} from 'linked-js/queries/CreateQuery.js';
+import {DeleteQueryFactory} from 'linked-js/queries/DeleteQuery.js';
+import {SelectQueryFactory} from 'linked-js/queries/SelectQuery.js';
+import {UpdateQueryFactory} from 'linked-js/queries/UpdateQuery.js';
+import {InMemoryStore} from '../stores/InMemoryStore.js';
+
+@linkedShape
+class Person extends Shape {
+  @literalProperty({path: 'name', maxCount: 1})
+  declare name: string;
+}
+
+describe('InMemoryStore CRUD', () => {
+  test('create, select, update, delete roundtrip', async () => {
+    const store = new InMemoryStore();
+
+    const createQuery = new CreateQueryFactory(Person, {name: 'Alice'}).getQueryObject();
+    const created = await store.createQuery<{id: string; name: string}>(createQuery);
+
+    expect(created.id).toBeDefined();
+    expect(created.name).toBe('Alice');
+
+    const selectQuery = new SelectQueryFactory(
+      Person,
+      (p) => p.name,
+      {id: created.id} as any,
+    ).getQueryObject();
+    const selected = await store.selectQuery<{id: string; name: string}>(selectQuery);
+
+    expect(selected.id).toBe(created.id);
+    expect(selected.name).toBe('Alice');
+
+    const updateQuery = new UpdateQueryFactory(Person, created.id, {name: 'Bob'}).getQueryObject();
+    const updated = await store.updateQuery<{id: string; name: string}>(updateQuery);
+
+    expect(updated.id).toBe(created.id);
+    expect(updated.name).toBe('Bob');
+
+    const afterUpdate = await store.selectQuery<{id: string; name: string}>(selectQuery);
+    expect(afterUpdate.name).toBe('Bob');
+
+    const deleteQuery = new DeleteQueryFactory(Person, created.id).getQueryObject();
+    const deleted = await store.deleteQuery(deleteQuery);
+
+    expect(deleted).toMatchObject({count: 1, deleted: [created.id]});
+  });
+});

--- a/rebrand/linked-mem-store/src/tests/store.test.ts
+++ b/rebrand/linked-mem-store/src/tests/store.test.ts
@@ -1,16 +1,12 @@
 import {describe, expect, test} from '@jest/globals';
-import {linkedShape, literalProperty, Shape} from 'linked-js';
+import {queryTestFixtures} from 'linked-js';
 import {CreateQueryFactory} from 'linked-js/queries/CreateQuery.js';
 import {DeleteQueryFactory} from 'linked-js/queries/DeleteQuery.js';
 import {SelectQueryFactory} from 'linked-js/queries/SelectQuery.js';
 import {UpdateQueryFactory} from 'linked-js/queries/UpdateQuery.js';
 import {InMemoryStore} from '../stores/InMemoryStore.js';
 
-@linkedShape
-class Person extends Shape {
-  @literalProperty({path: 'name', maxCount: 1})
-  declare name: string;
-}
+const {Person} = queryTestFixtures;
 
 describe('InMemoryStore CRUD', () => {
   test('create, select, update, delete roundtrip', async () => {

--- a/rebrand/linked-mem-store/src/utils/Debug.ts
+++ b/rebrand/linked-mem-store/src/utils/Debug.ts
@@ -1,0 +1,44 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+import {Literal,NamedNode,Node} from '../models.js';
+
+export class Debug {
+  //TODO: move stuff back into actual models, keep a general method here that handles numbers etc, so that imports of this file are minimal
+  //TODO: and so that dprint is not undefined if this file is not imported from index
+  static print(node, includeInverseProperties: boolean = true): string {
+    if (typeof node == 'number') {
+      node = NamedNode.TEMP_URI_BASE + node.toString();
+    }
+    if (typeof node == 'string') {
+      let namedNode = NamedNode.getNamedNode(node);
+      if (!namedNode) return node;
+      node = namedNode;
+    }
+    if (node instanceof Set || Array.isArray(node)) {
+      let r: string[] = [];
+      node.forEach((item) => r.push(this.print(item)));
+      return `Set [\n${r.join('\n')}\n]`;
+    }
+    if (node instanceof Literal) {
+      return node.toString();
+    }
+    if (node instanceof Node) {
+      return node.print();
+    }
+  }
+}
+
+//attach dprint to global or window object
+let g =
+  typeof window !== 'undefined'
+    ? window
+    : typeof global !== 'undefined'
+      ? global
+      : null;
+if (g) {
+  g['dprint'] = (item: any, includeIncomingProperties: boolean = true) =>
+    console.log(Debug.print(item, includeIncomingProperties));
+}

--- a/rebrand/linked-mem-store/src/utils/LocalQueryResolver.ts
+++ b/rebrand/linked-mem-store/src/utils/LocalQueryResolver.ts
@@ -1,0 +1,407 @@
+import {
+  AndOrQueryToken,
+  CustomQueryObject,
+  QueryPath,
+  QueryPropertyPath,
+  QueryStep,
+  SelectQuery,
+  SizeStep,
+  WhereAndOr,
+  WhereEvaluationPath,
+  WhereMethods,
+  WherePath,
+} from 'linked-js/queries/SelectQuery.js';
+import type {PropertyShape} from 'linked-js/shapes/PropertyShape.js';
+import type {NodeReferenceValue, NodeDescriptionValue, UpdateNodePropertyValue, UpdateValue, SetModificationValue} from 'linked-js/queries/MutationQuery.js';
+import type {CreateQuery} from 'linked-js/queries/CreateQuery.js';
+import type {UpdateQuery} from 'linked-js/queries/UpdateQuery.js';
+import type {DeleteQuery} from 'linked-js/queries/DeleteQuery.js';
+import {Graph, Literal, NamedNode, Node} from '../models.js';
+import {NodeSet} from '../collections/NodeSet.js';
+import {QuadSet} from '../collections/QuadSet.js';
+import {rdf} from '../ontologies/rdf.js';
+import {xsd} from '../ontologies/xsd.js';
+
+export type DeleteResponse = {
+  deleted: string[];
+  count: number;
+  failed?: string[];
+  errors?: Record<string, string>;
+};
+
+const toId = (value: string | {id?: string; uri?: string}): string => {
+  if (typeof value === 'string') {
+    return value;
+  }
+  return value?.id ?? value?.uri ?? '';
+};
+
+const toPredicate = (prop: PropertyShape) => {
+  const path = (prop.path as unknown as {id?: string} | string) || '';
+  const id = typeof path === 'string' ? path : path?.id;
+  return NamedNode.getOrCreate(id);
+};
+
+const toNodeReference = (node: NamedNode): NodeReferenceValue => ({id: node.uri});
+
+const nodeValueToPrimitive = (node: Node, prop?: PropertyShape) => {
+  if (node instanceof Literal) {
+    const datatypeId = (prop?.datatype as {id?: string} | undefined)?.id;
+    if (datatypeId === xsd.boolean.uri) {
+      return node.value === 'true';
+    }
+    if (datatypeId === xsd.integer.uri || datatypeId === xsd.decimal.uri || datatypeId === xsd.double.uri) {
+      return Number(node.value);
+    }
+    if (datatypeId === xsd.date.uri || datatypeId === xsd.dateTime.uri) {
+      return new Date(node.value);
+    }
+    return node.value;
+  }
+  if (node instanceof NamedNode) {
+    return {id: node.uri};
+  }
+  return undefined;
+};
+
+const convertUpdateValue = async (
+  prop: PropertyShape,
+  value: UpdateValue,
+  createQuery: boolean,
+): Promise<{value: Node | undefined; plainValue: unknown}> => {
+  if (typeof value === 'undefined') {
+    return {value: undefined, plainValue: undefined};
+  }
+  if (value === null) {
+    return {value: undefined, plainValue: undefined};
+  }
+  if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+    const datatypeId = (prop.datatype as {id?: string} | undefined)?.id;
+    if (datatypeId === xsd.date.uri || datatypeId === xsd.dateTime.uri) {
+      const dateValue = new Date(value as any);
+      return {value: new Literal(dateValue.toISOString(), xsd.dateTime), plainValue: dateValue};
+    }
+    return {value: new Literal(String(value), datatypeId ? NamedNode.getOrCreate(datatypeId) : undefined), plainValue: value};
+  }
+  if (value instanceof Date) {
+    return {value: new Literal(value.toISOString(), xsd.dateTime), plainValue: value};
+  }
+  if (Array.isArray(value)) {
+    return {value: undefined, plainValue: value};
+  }
+  if (typeof value === 'object') {
+    const record = value as Record<string, unknown>;
+    if ('id' in record || 'uri' in record) {
+      const id = toId(record as {id?: string; uri?: string});
+      return {value: NamedNode.getOrCreate(id), plainValue: {id}};
+    }
+    if ('fields' in record) {
+      const result = await convertNodeDescription(record as NodeDescriptionValue, createQuery);
+      return {value: result.value, plainValue: result.plainValue};
+    }
+  }
+  return {value: undefined, plainValue: undefined};
+};
+
+const applySetModification = async (
+  subject: NamedNode,
+  prop: PropertyShape,
+  value: SetModificationValue,
+  createQuery: boolean,
+  plainValues: Record<string, unknown>,
+) => {
+  const predicate = toPredicate(prop);
+  if (value.$remove) {
+    value.$remove.forEach((removeValue) => {
+      const id = toId(removeValue);
+      const node = NamedNode.getNamedNode(id);
+      if (node) {
+        subject.unset(predicate, node);
+      }
+    });
+  }
+  if (value.$add) {
+    const addedValues: unknown[] = [];
+    for (const addValue of value.$add) {
+      const res = await convertUpdateValue(prop, addValue, createQuery);
+      if (res.value) {
+        subject.set(predicate, res.value);
+        addedValues.push(res.plainValue);
+      }
+    }
+    plainValues[prop.label] = createQuery ? addedValues : {updatedTo: addedValues};
+  }
+};
+
+const applyFieldUpdates = async (
+  fields: UpdateNodePropertyValue[],
+  subject: NamedNode,
+  createQuery: boolean,
+): Promise<Record<string, unknown>> => {
+  const plainValues: Record<string, unknown> = {};
+  for (const field of fields) {
+    const propShape = field.prop;
+    const predicate = toPredicate(propShape);
+    const value = field.val;
+
+    if (typeof value === 'undefined') {
+      subject.unsetAll(predicate);
+      plainValues[propShape.label] = propShape.maxCount === 1 ? undefined : [];
+      continue;
+    }
+
+    if (Array.isArray(value)) {
+      const values: Node[] = [];
+      const plainArray: unknown[] = [];
+      for (const item of value) {
+        const res = await convertUpdateValue(propShape, item, createQuery);
+        if (res.value) {
+          values.push(res.value);
+        }
+        plainArray.push(res.plainValue);
+      }
+      subject.moverwrite(predicate, values);
+      plainValues[propShape.label] = createQuery ? plainArray : {updatedTo: plainArray};
+      continue;
+    }
+
+    if (typeof value === 'object' && value && ('$add' in value || '$remove' in value)) {
+      await applySetModification(subject, propShape, value as SetModificationValue, createQuery, plainValues);
+      continue;
+    }
+
+    const res = await convertUpdateValue(propShape, value, createQuery);
+    if (res.value) {
+      subject.overwrite(predicate, res.value);
+      plainValues[propShape.label] = res.plainValue;
+    }
+  }
+  return plainValues;
+};
+
+const convertNodeDescription = async (
+  description: NodeDescriptionValue,
+  createQuery: boolean,
+): Promise<{value: NamedNode; plainValue: Record<string, unknown>}> => {
+  const id = description.__id ? description.__id : undefined;
+  const subject = id ? NamedNode.getOrCreate(id) : NamedNode.create();
+  if ((description.shape as any)?.targetClass?.id) {
+    subject.set(
+      rdf.type,
+      NamedNode.getOrCreate((description.shape as any).targetClass.id),
+    );
+  }
+  const plainValues = await applyFieldUpdates(description.fields, subject, createQuery);
+  plainValues.id = subject.uri;
+  return {value: subject, plainValue: plainValues};
+};
+
+const resolveWhereEvaluation = (
+  subject: NamedNode,
+  evaluation: WhereEvaluationPath,
+): boolean => {
+  const endValues = resolveQueryPathEndResults(subject, evaluation.path);
+  const arg = evaluation.args[0];
+  const expected = typeof arg === 'object' && arg && 'id' in arg ? (arg as {id: string}).id : arg;
+  return endValues.some((value) => {
+    if (typeof expected === 'string' && value instanceof NamedNode) {
+      return value.uri === expected;
+    }
+    if (value instanceof Literal) {
+      return value.value === String(expected);
+    }
+    return false;
+  });
+};
+
+const resolveWhere = (subject: NamedNode, where: WherePath): boolean => {
+  if (!where) return true;
+  if ('method' in where) {
+    if (where.method === WhereMethods.EQUALS) {
+      return resolveWhereEvaluation(subject, where);
+    }
+    return false;
+  }
+  const andOr = where as WhereAndOr;
+  let result = resolveWhere(subject, andOr.firstPath);
+  andOr.andOr.forEach((token: AndOrQueryToken) => {
+    if (token.and) {
+      result = result && resolveWhere(subject, token.and);
+    }
+    if (token.or) {
+      result = result || resolveWhere(subject, token.or);
+    }
+  });
+  return result;
+};
+
+const resolveQueryPathEndResults = (
+  subject: NamedNode,
+  path: QueryPropertyPath,
+): Node[] => {
+  let current: NodeSet<NamedNode> = new NodeSet([subject]);
+  for (const step of path) {
+    if (!('property' in step)) {
+      continue;
+    }
+    const predicate = toPredicate(step.property);
+    const next = new NodeSet<NamedNode>();
+    current.forEach((node) => {
+      node.getAll(predicate).forEach((value) => {
+        if (value instanceof NamedNode) {
+          next.add(value);
+        }
+      });
+    });
+    current = next;
+  }
+  return Array.from(current.values());
+};
+
+const resolveSizeStep = (subject: NamedNode, step: SizeStep): number => {
+  const values = resolveQueryPathEndResults(subject, step.count);
+  return values.length;
+};
+
+const resolvePathValues = (
+  subject: NamedNode,
+  path: QueryStep[],
+): unknown => {
+  if (path.length === 0) {
+    return {id: subject.uri};
+  }
+  const [step, ...rest] = path;
+  if ('count' in step) {
+    return resolveSizeStep(subject, step);
+  }
+  const predicate = toPredicate(step.property);
+  const values = subject.getAll(predicate);
+  const filteredValues = step.where
+    ? new NodeSet<NamedNode>(
+        Array.from(values).filter((value) =>
+          value instanceof NamedNode ? resolveWhere(value, step.where) : true,
+        ) as NamedNode[],
+      )
+    : values;
+
+  const results: unknown[] = [];
+  filteredValues.forEach((value) => {
+    if (rest.length === 0) {
+      results.push(nodeValueToPrimitive(value, step.property));
+    } else if (value instanceof NamedNode) {
+      results.push(resolvePathValues(value, rest));
+    }
+  });
+  if (step.property.maxCount === 1) {
+    return results[0];
+  }
+  return results;
+};
+
+const applyQueryPath = (
+  result: Record<string, unknown>,
+  subject: NamedNode,
+  path: QueryPath,
+) => {
+  if (Array.isArray(path)) {
+    if (path.length === 0) return;
+    if (Array.isArray(path[0])) {
+      (path as QueryPath[]).forEach((subPath) => {
+        applyQueryPath(result, subject, subPath);
+      });
+      return;
+    }
+    const firstStep = path[0] as QueryStep;
+    if ('property' in firstStep) {
+      const value = resolvePathValues(subject, path as QueryStep[]);
+      result[firstStep.property.label] = value;
+    }
+    return;
+  }
+  if (typeof path === 'object') {
+    Object.entries(path as CustomQueryObject).forEach(([key, subPath]) => {
+      const nested: Record<string, unknown> = {};
+      applyQueryPath(nested, subject, subPath);
+      result[key] = nested;
+    });
+  }
+};
+
+const resolveSelect = (query: SelectQuery): Record<string, unknown>[] => {
+  let subjects: NamedNode[] = [];
+  if (query.subject && typeof query.subject === 'object' && 'id' in query.subject) {
+    subjects = [NamedNode.getOrCreate((query.subject as {id: string}).id)];
+  } else if (typeof query.subject === 'string') {
+    subjects = [NamedNode.getOrCreate(query.subject)];
+  } else if ((query.shape as any)?.shape?.targetClass?.id) {
+    const target = NamedNode.getOrCreate((query.shape as any).shape.targetClass.id);
+    subjects = Array.from(NamedNode.getAllNamedNodes().values()).filter((node) =>
+      node.has(rdf.type, target),
+    );
+  }
+
+  const results: Record<string, unknown>[] = [];
+  subjects.forEach((subject) => {
+    if (query.where && !resolveWhere(subject, query.where)) {
+      return;
+    }
+    const result: Record<string, unknown> = {id: subject.uri};
+    query.select.forEach((path) => applyQueryPath(result, subject, path));
+    results.push(result);
+  });
+  return results;
+};
+
+export async function createLocal<ResultType>(
+  query: CreateQuery<ResultType>,
+): Promise<ResultType> {
+  const result = await convertNodeDescription(query.description, true);
+  return result.plainValue as ResultType;
+}
+
+export async function updateLocal<ResultType>(
+  query: UpdateQuery<ResultType>,
+): Promise<ResultType> {
+  const subject = NamedNode.getOrCreate(query.id);
+  const plainValues = await applyFieldUpdates(query.updates.fields, subject, false);
+  plainValues.id = subject.uri;
+  return plainValues as ResultType;
+}
+
+export async function deleteLocal(query: DeleteQuery): Promise<DeleteResponse> {
+  const response: DeleteResponse = {deleted: [], count: 0};
+  const errors: Record<string, string> = {};
+  const failed: string[] = [];
+  query.ids.forEach((idValue) => {
+    const id = toId(idValue as {id?: string; uri?: string} | string);
+    const node = NamedNode.getNamedNode(id);
+    if (!node) {
+      failed.push(id);
+      errors[id] = `No node found with id: ${id}`;
+      return;
+    }
+    node.remove();
+    response.deleted.push(id);
+    response.count += 1;
+  });
+  if (failed.length > 0) {
+    response.failed = failed;
+    response.errors = errors;
+  }
+  return response;
+}
+
+export async function resolveLocal<ResultType>(
+  query: SelectQuery,
+): Promise<ResultType> {
+  if (query.type !== 'select') {
+    throw new Error('Invalid query type');
+  }
+  const results = resolveSelect(query);
+  return (query.singleResult ? results[0] : results) as ResultType;
+}
+
+export function resetLocalStore() {
+  NamedNode.reset();
+  Graph.reset();
+}

--- a/rebrand/linked-mem-store/src/utils/LocalQueryResolver.ts
+++ b/rebrand/linked-mem-store/src/utils/LocalQueryResolver.ts
@@ -64,6 +64,16 @@ const nodeValueToPrimitive = (node: Node, prop?: PropertyShape) => {
   return undefined;
 };
 
+const normalizeWhereValue = (value: unknown, prop?: PropertyShape) => {
+  if (value instanceof Literal) {
+    return nodeValueToPrimitive(value, prop);
+  }
+  if (value instanceof NamedNode) {
+    return {id: value.uri};
+  }
+  return value;
+};
+
 const convertUpdateValue = async (
   prop: PropertyShape,
   value: UpdateValue,
@@ -202,16 +212,47 @@ const resolveWhereEvaluation = (
 ): boolean => {
   const endValues = resolveQueryPathEndResults(subject, evaluation.path);
   const arg = evaluation.args[0];
-  const expected = typeof arg === 'object' && arg && 'id' in arg ? (arg as {id: string}).id : arg;
+  const expected =
+    typeof arg === 'object' && arg && 'id' in arg ? (arg as {id: string}).id : arg;
+  const lastPropertyStep = [...evaluation.path]
+    .reverse()
+    .find((step) => 'property' in step) as {property?: PropertyShape} | undefined;
+  const prop = lastPropertyStep?.property;
   return endValues.some((value) => {
-    if (typeof expected === 'string' && value instanceof NamedNode) {
-      return value.uri === expected;
+    const normalized = normalizeWhereValue(value, prop);
+    if (
+      normalized &&
+      typeof normalized === 'object' &&
+      'id' in normalized &&
+      typeof (normalized as {id: string}).id === 'string'
+    ) {
+      return typeof expected === 'string'
+        ? (normalized as {id: string}).id === expected
+        : false;
     }
-    if (value instanceof Literal) {
-      return value.value === String(expected);
-    }
-    return false;
+    return normalized === expected;
   });
+};
+
+const resolveWhereSomeEvery = (
+  subject: NamedNode,
+  evaluation: WhereEvaluationPath,
+  method: WhereMethods.SOME | WhereMethods.EVERY,
+): boolean => {
+  const arg = evaluation.args[0];
+  if (!arg || typeof arg !== 'object') {
+    return false;
+  }
+  const nodes = resolveQueryPathEndResults(subject, evaluation.path).filter(
+    (value) => value instanceof NamedNode,
+  ) as NamedNode[];
+  if (nodes.length === 0) {
+    return false;
+  }
+  const predicate = (node: NamedNode) => resolveWhere(node, arg as WherePath);
+  return method === WhereMethods.SOME
+    ? nodes.some(predicate)
+    : nodes.every(predicate);
 };
 
 const resolveWhere = (subject: NamedNode, where: WherePath): boolean => {
@@ -219,6 +260,9 @@ const resolveWhere = (subject: NamedNode, where: WherePath): boolean => {
   if ('method' in where) {
     if (where.method === WhereMethods.EQUALS) {
       return resolveWhereEvaluation(subject, where);
+    }
+    if (where.method === WhereMethods.SOME || where.method === WhereMethods.EVERY) {
+      return resolveWhereSomeEvery(subject, where, where.method);
     }
     return false;
   }
@@ -240,22 +284,27 @@ const resolveQueryPathEndResults = (
   path: QueryPropertyPath,
 ): Node[] => {
   let current: NodeSet<NamedNode> = new NodeSet([subject]);
-  for (const step of path) {
+  let values: Node[] = [];
+  path.forEach((step, index) => {
     if (!('property' in step)) {
-      continue;
+      return;
     }
     const predicate = toPredicate(step.property);
     const next = new NodeSet<NamedNode>();
+    const isLast = index === path.length - 1;
     current.forEach((node) => {
       node.getAll(predicate).forEach((value) => {
         if (value instanceof NamedNode) {
           next.add(value);
         }
+        if (isLast) {
+          values.push(value);
+        }
       });
     });
     current = next;
-  }
-  return Array.from(current.values());
+  });
+  return values;
 };
 
 const resolveSizeStep = (subject: NamedNode, step: SizeStep): number => {
@@ -314,7 +363,8 @@ const applyQueryPath = (
     const firstStep = path[0] as QueryStep;
     if ('property' in firstStep) {
       const value = resolvePathValues(subject, path as QueryStep[]);
-      result[firstStep.property.label] = value;
+      result[firstStep.property.label] =
+        typeof value === 'undefined' ? null : value;
     }
     return;
   }
@@ -330,9 +380,15 @@ const applyQueryPath = (
 const resolveSelect = (query: SelectQuery): Record<string, unknown>[] => {
   let subjects: NamedNode[] = [];
   if (query.subject && typeof query.subject === 'object' && 'id' in query.subject) {
-    subjects = [NamedNode.getOrCreate((query.subject as {id: string}).id)];
+    const node = NamedNode.getNamedNode((query.subject as {id: string}).id);
+    if (node) {
+      subjects = [node];
+    }
   } else if (typeof query.subject === 'string') {
-    subjects = [NamedNode.getOrCreate(query.subject)];
+    const node = NamedNode.getNamedNode(query.subject);
+    if (node) {
+      subjects = [node];
+    }
   } else if ((query.shape as any)?.shape?.targetClass?.id) {
     const target = NamedNode.getOrCreate((query.shape as any).shape.targetClass.id);
     subjects = Array.from(NamedNode.getAllNamedNodes().values()).filter((node) =>
@@ -346,7 +402,11 @@ const resolveSelect = (query: SelectQuery): Record<string, unknown>[] => {
       return;
     }
     const result: Record<string, unknown> = {id: subject.uri};
-    query.select.forEach((path) => applyQueryPath(result, subject, path));
+    if (Array.isArray(query.select)) {
+      query.select.forEach((path) => applyQueryPath(result, subject, path));
+    } else {
+      applyQueryPath(result, subject, query.select);
+    }
     results.push(result);
   });
   return results;

--- a/rebrand/linked-mem-store/src/utils/Prefix.ts
+++ b/rebrand/linked-mem-store/src/utils/Prefix.ts
@@ -1,0 +1,108 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+import {CoreMap} from '../collections/CoreMap.js';
+
+export class Prefix {
+  static uriToPrefix: CoreMap<string, string> = new CoreMap();
+  static prefixToUri: CoreMap<string, string> = new CoreMap();
+
+  static getUriToPrefixMap() {
+    return this.uriToPrefix;
+  }
+
+  static getPrefixToUriMap() {
+    return this.prefixToUri;
+  }
+
+  static add(prefix: string, fullURI: string) {
+    this.uriToPrefix.set(fullURI, prefix);
+    this.prefixToUri.set(prefix, fullURI);
+  }
+
+  static delete(prefix: string) {
+    if (this.prefixToUri.has(prefix)) {
+      let fullURI = this.getFullURI(prefix);
+      this.uriToPrefix.delete(fullURI);
+      this.prefixToUri.delete(prefix);
+    }
+  }
+
+  static clear() {
+    this.uriToPrefix = new CoreMap<string, string>();
+    this.prefixToUri = new CoreMap<string, string>();
+  }
+
+  static getPrefix(fullURI: string): string {
+    if (this.uriToPrefix.has(fullURI)) {
+      return this.uriToPrefix.get(fullURI);
+    }
+    let match = this.findMatch(fullURI);
+    if (match.length > 0) return match[1];
+  }
+
+  static getFullURI(prefix: string): string {
+    return this.prefixToUri.get(prefix);
+  }
+
+
+  static findMatch(fullURI: string): [string, string, string] | [] {
+    for (let [ontologyURI, prefix] of this.uriToPrefix.entries()) {
+      if (fullURI.substring(0, ontologyURI.length) == ontologyURI) {
+        return [ontologyURI, prefix, fullURI.substring(ontologyURI.length)];
+      }
+    }
+    return [];
+  }
+
+  static toPrefixed(fullURI: string) {
+    let match = this.findMatch(fullURI);
+    if (match.length > 0) {
+      const postFix = fullURI.substring(match[0].length);
+      if (!postFix.includes('/')) {
+        return match[1] + ':' + postFix;
+      }
+    }
+  }
+
+  static toPrefixedIfPossible(fullURI: string) {
+    return this.toPrefixed(fullURI) || fullURI;
+  }
+
+  static toFullIfPossible(fullURI: string): string {
+    let res = this._toFull(fullURI);
+    if(res) {
+      return res;
+    }
+    return fullURI;
+  }
+
+  /**
+   * Converts a prefixed URI back to its full URI
+   * Will return the prefixed URI if no prefix was found
+   * @param uri
+   */
+  static toFull(uri) {
+    let res = this._toFull(uri);
+    if(res) {
+      return res;
+    }
+    let [prefix, rest] = uri.split(':');
+    throw new Error(
+      'Unknown prefix ' +
+        prefix +
+        '. Could not convert ' +
+        uri +
+        ' to a full URI',
+    );
+  }
+  private static _toFull(uri) {
+    let [prefix, rest] = uri.split(':');
+    let ontologyURI = this.getFullURI(prefix);
+    if (ontologyURI) {
+      return ontologyURI + rest;
+    }
+  }
+}

--- a/rebrand/linked-mem-store/src/utils/URI.ts
+++ b/rebrand/linked-mem-store/src/utils/URI.ts
@@ -1,0 +1,40 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+export class URI {
+  /**
+   * Function: sanitize
+   * Returns a sanitized string, typically for URLs.
+   *
+   * Parameters:
+   *     $string - The string to sanitize.
+   *     $force_lowercase - Force the string to lowercase?
+   */
+  static sanitize(string) {
+    if (!string) return string;
+    //\u200B is the ZERO WIDTH SPACE, often introduced by WYSIWYG editors. This causes a hyphen (-) at the end of a string sometimes, so we filter it out first
+    return string
+      .replace(/\u200B/g, '')
+      .replace(/[^\w]+/g, '-')
+      .toLowerCase();
+  }
+
+  static isURI(uri: string) {
+    //must have a scheme followed by ://
+    return /([A-Za-z][A-Za-z0-9+\-.]*)\:\/\//.test(uri);
+  }
+
+  /**
+   * Generate a new URI based on the given URI components (labels / identifiers).
+   * This URI will start with the DATA_ROOT environment variable
+   * @param uriComponents
+   */
+  static generate(...uriComponents: string[]) {
+    return (
+      process.env.DATA_ROOT +
+      uriComponents.filter(Boolean).map(encodeURIComponent).join('/')
+    );
+  }
+}

--- a/rebrand/linked-mem-store/tsconfig-cjs.json
+++ b/rebrand/linked-mem-store/tsconfig-cjs.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "es6",
+    "outDir": "lib/cjs"
+  }
+}

--- a/rebrand/linked-mem-store/tsconfig-esm.json
+++ b/rebrand/linked-mem-store/tsconfig-esm.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "esnext",
+    "target": "es6",
+    "outDir": "lib/esm",
+    "moduleResolution": "node"
+  }
+}

--- a/rebrand/linked-mem-store/tsconfig.json
+++ b/rebrand/linked-mem-store/tsconfig.json
@@ -2,6 +2,8 @@
   "compilerOptions": {
     "sourceMap": true,
     "declaration": true,
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true,
     "downlevelIteration": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
@@ -10,7 +12,9 @@
     "types": ["node", "jest"],
     "baseUrl": "./",
     "paths": {
-      "*": ["node_modules/@types/*", "../../node_modules/@types/*", "*"]
+      "*": ["node_modules/@types/*", "../../node_modules/@types/*", "*"],
+      "linked-js": ["../linked-js/src/index.ts"],
+      "linked-js/*": ["../linked-js/src/*"]
     }
   },
   "include": [

--- a/rebrand/linked-mem-store/tsconfig.json
+++ b/rebrand/linked-mem-store/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "sourceMap": true,
+    "declaration": true,
+    "downlevelIteration": true,
+    "resolveJsonModule": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "pretty": true,
+    "types": ["node", "jest"],
+    "baseUrl": "./",
+    "paths": {
+      "*": ["node_modules/@types/*", "../../node_modules/@types/*", "*"]
+    }
+  },
+  "include": [
+    "./src/**/*.ts",
+    "../node_modules/ts-jest/globals.d.ts"
+  ]
+}

--- a/rebranding.md
+++ b/rebranding.md
@@ -1,0 +1,29 @@
+# Linked Rebrand Plan (linked-js package extraction)
+
+## Goal
+Create a new `linked-js` package under `rebrand/linked-js` that contains the SHACL/shape/query DSL stack (no React and no RDF model classes). The new package should build cleanly and provide test coverage that validates the generated JS query objects from the TypeScript DSL.
+
+## Phased Plan
+1. **Create package skeleton**
+   - Add `rebrand/linked-js/package.json`, `tsconfig.json`, and a minimal test runner (Jest or equivalent).
+   - Add a single trivial test to verify the test harness runs.
+2. **Seed with the simplest query test**
+   - Identify the simplest existing query test (e.g., `Person.select(p => p.name)` or `Person.create` with one literal).
+   - Copy only the minimal shape/query infrastructure required for this test.
+   - Implement a way to capture the query object produced by the DSL without needing a backing store.
+   - Assert on the captured query object rather than the query results.
+3. **Incrementally port remaining tests**
+   - Migrate tests one by one, each time copying only the minimum necessary code.
+   - Keep tests focused on query-object generation (selection paths, where clauses, sorting, limits, updates/creates) rather than executing queries.
+4. **Clean up dependencies**
+   - Ensure no React dependencies remain.
+   - Remove RDF model class dependencies (e.g., `NamedNode`, `Literal`, `Quad`).
+   - Replace any remaining runtime store logic with query-object captures/mocks.
+5. **Validate build + tests**
+   - Run the new package build and test suites to confirm the package is standalone.
+
+## Milestones
+- Skeleton package with a passing trivial test.
+- First DSL-to-query-object test passing.
+- Full query test suite migrated (with updated assertions).
+- Zero React/RDF model dependencies in `linked-js`.

--- a/src/tests/utils/query-tests.tsx
+++ b/src/tests/utils/query-tests.tsx
@@ -387,6 +387,7 @@ export const runQueryTests = (startPromise = Promise.resolve()) => {
       test('select with a non existing returns undefined',async () => {
         let qRes = await Person.select({id: 'https://does.not/exist'},p => p.name);
         expect(qRes).toBeUndefined();
+        expect(NamedNode.getNamedNode('https://does.not/exist')).toBeUndefined();
       });
 
       test('selecting only undefined properties returns an empty object',async () => {
@@ -2921,4 +2922,3 @@ export const runQueryTests = (startPromise = Promise.resolve()) => {
 //We can keep it more simple for now by flattening horizontal paths
 //its less like graph-QL, but easier to implement with auto complete
 //and we already have shape results for graphQL like experience
-

--- a/src/utils/LocalQueryResolver.ts
+++ b/src/utils/LocalQueryResolver.ts
@@ -671,9 +671,9 @@ export function resolveLocal<ResultType>(
       }
       if (NamedNode.getNamedNode((query.subject as QResult<any>).id)) {
         // subject = query.shape.getFromURI((query.subject as QResult<any>).id) as Shape;
-        subject = NamedNode.getOrCreate((query.subject as QResult<any>).id);
+        subject = NamedNode.getNamedNode((query.subject as QResult<any>).id);
       } else {
-        return null;
+        return undefined;
       }
     } else if (query.subject instanceof ShapeSet) {
       subject = (query.subject as ShapeSet).getNodes() as NodeSet<NamedNode>;
@@ -849,6 +849,9 @@ function resolveQueryPath(
   queryPath: QueryPath | ComponentQueryPath,
   resultObjects?: NodeResultMap | QResult<any, any>,
 ) {
+  if (!subject) {
+    return subject;
+  }
   //start with the local instance as the subject
   if (Array.isArray(queryPath)) {
     //if the queryPath is an array of query steps, then resolve the query steps and let that convert the result
@@ -867,6 +870,9 @@ function resolveQueryPathEndResults(
   subject: NodeSet<NamedNode> | NamedNode,
   queryPath: QueryPath | ComponentQueryPath,
 ) {
+  if (!subject) {
+    return subject as any;
+  }
   //start with the local instance as the subject
   let result: NodeSet<NamedNode> | NamedNode[] | NamedNode | boolean[] =
     subject;
@@ -947,10 +953,10 @@ function sortResults(
  * @private
  */
 function filterResults(
-  subject: NodeSet<NamedNode> | NamedNode,
+  subject: NodeSet<NamedNode> | NamedNode | Literal | JSPrimitive | any[],
   where: WherePath,
   resultObjects?: NodeResultMap,
-): NodeSet<NamedNode> | NamedNode {
+): NodeSet<NamedNode> | NamedNode | Literal | JSPrimitive | any[] {
   // if ((where as WhereEvaluationPath).path) {
   //for nested where clauses the subject will already be a QueryValue
   //TODO: check if subject is ever not a shape, shapeset or string
@@ -965,11 +971,22 @@ function filterResults(
       }
     });
     return subject;
+  } else if (Array.isArray(subject)) {
+    return subject.filter((node) => evaluate(node as any, where)) as any;
   } else if (subject instanceof NamedNode) {
     return evaluate(subject, where as WhereEvaluationPath)
       ? subject
       : undefined;
-  } else if (typeof subject === 'string') {
+  } else if (subject instanceof Literal) {
+    return evaluate(subject, where as WhereEvaluationPath)
+      ? subject
+      : undefined;
+  } else if (
+    typeof subject === 'string' ||
+    typeof subject === 'number' ||
+    typeof subject === 'boolean' ||
+    subject instanceof Date
+  ) {
     return evaluate(subject, where as WhereEvaluationPath)
       ? subject
       : undefined;
@@ -1023,12 +1040,18 @@ function resolveWhereArgs(args: QueryArg[]) {
   });
 }
 
-function evaluate(singleNode: NamedNode, where: WherePath): boolean {
+function evaluate(
+  singleNode: NamedNode | JSPrimitive | Literal,
+  where: WherePath,
+): boolean {
   if ((where as WhereEvaluationPath).path) {
-    let shapeEndValue = resolveQueryPathEndResults(
-      singleNode,
-      (where as WhereEvaluationPath).path,
-    );
+    let shapeEndValue =
+      singleNode instanceof NamedNode
+        ? resolveQueryPathEndResults(
+            singleNode,
+            (where as WhereEvaluationPath).path,
+          )
+        : normalizeWhereValue(singleNode);
 
     let args: any[] =
       (where as ProcessedWhereEvaluationPath).processedArgs ||
@@ -1144,32 +1167,46 @@ function evaluate(singleNode: NamedNode, where: WherePath): boolean {
 }
 
 function resolveWhereEquals(queryEndValue, otherValue: any) {
-  if (
-    queryEndValue instanceof NamedNode &&
-    (otherValue as NodeReferenceValue).id
-  ) {
-    return queryEndValue.uri === otherValue.id;
+  const normalizedQueryValue = normalizeWhereValue(queryEndValue);
+  const normalizedOtherValue = normalizeWhereValue(otherValue);
+  if (normalizedQueryValue instanceof NamedNode) {
+    if ((normalizedOtherValue as NodeReferenceValue)?.id) {
+      return normalizedQueryValue.uri === normalizedOtherValue.id;
+    }
+    if (normalizedOtherValue instanceof NamedNode) {
+      return normalizedQueryValue.uri === normalizedOtherValue.uri;
+    }
   }
-  return queryEndValue === otherValue;
+  return normalizedQueryValue === normalizedOtherValue;
 }
 
 function resolveWhereSome(
-  nodes: NodeSet<NamedNode>,
+  nodes: NodeSet<NamedNode> | any[],
   evaluation: WhereEvaluationPath,
 ) {
-  return nodes.some((node) => {
-    return evaluate(node, evaluation);
-  });
+  if (!nodes) {
+    return false;
+  }
+  if (nodes instanceof NodeSet || Array.isArray(nodes)) {
+    return nodes.some((node) => {
+      return evaluate(node as any, evaluation);
+    });
+  }
+  return false;
 }
 
 function resolveWhereEvery(nodes, evaluation: WhereEvaluationPath) {
+  if (!nodes) {
+    return false;
+  }
+  const values = nodes instanceof NodeSet ? [...nodes] : nodes;
   //there is an added check to see if there are any shapes
   // because for example for this query where(p => p.friends.every(f => f.name.equals('Semmy')))
   // it would be natural to expect that if there are no friends, the query would return false
   return (
-    nodes.size > 0 &&
-    nodes.every((node) => {
-      return evaluate(node, evaluation);
+    values.length > 0 &&
+    values.every((node) => {
+      return evaluate(node as any, evaluation);
     })
   );
 }
@@ -1184,6 +1221,9 @@ function resolveQuerySteps(
   queryPath: (QueryStep | SubQueryPaths)[],
   resultObjects?: NodeResultMap | QResult<any, any>,
 ) {
+  if (!subject) {
+    return subject;
+  }
   if (queryPath.length === 0) {
     return subject;
   }
@@ -1199,7 +1239,10 @@ function resolveQuerySteps(
     // let shape = getShapeClass(NamedNode.getNamedNode((currentStep as ShapeReferenceValue).shape.id));
     // const shapeInstance = (shape as any).getFromURI((currentStep as ShapeReferenceValue).id) as Shape;
     // subject = shapeInstance;
-    subject = NamedNode.getOrCreate((currentStep as ShapeReferenceValue).id);
+    subject = NamedNode.getNamedNode((currentStep as ShapeReferenceValue).id);
+    if (!subject) {
+      return undefined;
+    }
     //continue with the next step for this new subject
     [currentStep, ...restPath] = restPath;
   }
@@ -1749,6 +1792,10 @@ function resolveQueryStepForNodesEndResults(
       }
     });
     return result;
+  } else if ((queryStep as SizeStep).count) {
+    return subject.map((singleNode) =>
+      resolveCountStep(singleNode, queryStep as SizeStep),
+    );
   } else if ((queryStep as PropertyQueryStep).where) {
     //in some cases there is a query step without property but WITH where
     //this happens when the where clause is on the root of the query
@@ -1760,6 +1807,30 @@ function resolveQueryStepForNodesEndResults(
     );
     return whereResult;
   }
+}
+
+function normalizeWhereValue(value: any) {
+  if (value instanceof Literal) {
+    return literalToPrimitiveForWhere(value);
+  }
+  return value;
+}
+
+function literalToPrimitiveForWhere(literal: Literal): JSPrimitive {
+  let datatype = literal.datatype;
+  let value = literal.value;
+  if (datatype) {
+    if (datatype.equals(xsd.boolean)) {
+      return value === 'true';
+    } else if (datatype.equals(xsd.integer)) {
+      return parseInt(value);
+    } else if (datatype.equals(xsd.decimal) || datatype.equals(xsd.double)) {
+      return parseFloat(value);
+    } else if (datatype.equals(xsd.date) || datatype.equals(xsd.dateTime)) {
+      return new Date(value);
+    }
+  }
+  return value;
 }
 
 function XSDDate_fromNativeDate(nativeDate: Date, datatype) {


### PR DESCRIPTION
### Motivation
- Remove the split between a mutable `shapeDefinition` and a separate plain-JS `NodeShapeResult` and keep a single mutable shape instance for decorators and runtime use.
- Make query/mutation payload typing follow the actual runtime `NodeShape` structure by using `QResult<NodeShape>` so types auto-align with the implementation.
- Expose a JS-friendly `properties` getter on the shape to produce QResult-style property payloads without a separate result type.

### Description
- Replaced the former `ShapeDefinition`/`NodeShapeResult` pattern with a single `NodeShape` class that holds `PropertyShape` instances and exposes `getPropertyShapes()` and a `properties` getter returning plain property results.
- Updated `Shape` to store a single mutable `static shape: NodeShape` and adjusted decorators in `shapes/decorators.ts` to initialize and populate that `NodeShape` (including stable property IDs and value-shape refs).
- Switched mutation and query types to use `QResult<NodeShape>` (queries: `CreateQuery`, `UpdateQuery`, `DeleteQuery`, `MutationQuery`), and updated the mutation builders to consume the unified `NodeShape` instance when converting update payloads.
- Added/updated routing and parser utilities (`QueryParser`, `LinkedStorage`, `Package`, `ShapeClass` helpers) and expanded `SelectQuery` to support richer query shapes (where clauses, aggregations, sub-selects) and to patch returned promise with helper methods like `where`, `limit`, `one`, and `sortBy`.
- Updated tests to use the unified `shape` and added new tests for CRUD routing and richer select behavior; adjusted `PropertyShape` to support node refs, datatypes, counts and to return `PropertyShapeResult`.

### Testing
- Built and ran the library and tests with: `cd rebrand/linked-js && node ../../node_modules/.bin/rimraf ./lib && node ../../node_modules/.bin/tsc -p tsconfig-cjs.json && node ../../node_modules/.bin/tsc -p tsconfig-esm.json && node ./scripts/dual-package.js && node ../../node_modules/.bin/jest --config jest.config.cjs`.
- All automated tests passed: Test Suites: 4 passed, Tests: 37 passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697f4747cd788322abb6fd0e4fceb2a0)